### PR TITLE
Optimize for smaller window sizes

### DIFF
--- a/jekyll/_docs/airbrake-faq/how-do-i-use-the-airbrake-heroku-addon.md
+++ b/jekyll/_docs/airbrake-faq/how-do-i-use-the-airbrake-heroku-addon.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: How do I use the Airbrake heroku addon
+short-title: Heroku addon
 categories: [airbrake-faq]
 last_updated: May 11, 2016
 description: how do I use the Airbrake heroku addon

--- a/jekyll/_docs/airbrake-faq/what-ips-should-i-whitelist-for-my-firewall.md
+++ b/jekyll/_docs/airbrake-faq/what-ips-should-i-whitelist-for-my-firewall.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: What IP Should I whitelist for my firewall
+short-title: Firewall IP whitelisting
 categories: [airbrake-faq]
 last_updated: May 11, 2016
 description: What IP should I whitelist for my firewall

--- a/jekyll/_docs/airbrake-faq/when-does-my-remember-me-cookie-expire.md
+++ b/jekyll/_docs/airbrake-faq/when-does-my-remember-me-cookie-expire.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: When does my remember me cookie expire
+short-title: Remeber me cookie expiration
 categories: [airbrake-faq]
 last_updated: May 11, 2016
 description: when does my remember me cookie expire

--- a/jekyll/_docs/installing-airbrake/sending-uncaught-python-exceptions-to-airbrake.md
+++ b/jekyll/_docs/installing-airbrake/sending-uncaught-python-exceptions-to-airbrake.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Sending uncaught Python exceptions to Airbrake
-short-title: Capturing uncaught Python exceptions
+short-title: Uncaught Python exceptions
 categories: [installing-airbrake]
 last_updated: May 11, 2016
 description: Sending uncaught Python exceptions to Airbrake

--- a/jekyll/_docs/integrations/third-party-integrations-with-airbrake.md
+++ b/jekyll/_docs/integrations/third-party-integrations-with-airbrake.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Third party integrations with Airbrake
+short-title: Third party integrations
 categories: [integrations]
 last_updated: May 11, 2016
 description: Third party integrations with Airbrake

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -7,10 +7,10 @@
   {% include global-nav.html %}
   <div class="container-fluid container-fluid--ab">
     <div class="row ab-md-row-flex">
-      <div class="col-md-4 col-lg-3">
+      <div class="col-xs-3 col-sm-4 col-md-4 col-lg-3">
         {% include sidebar.html %}
       </div>
-      <div class="col-md-8 col-lg-9 content-wrap">
+      <div class="col-xs-9 col-sm-8 col-md-8 col-lg-9 content-wrap">
         <div class="content">
           <form id="site-search" class="site-search" action="">
             <input type="text" autocomplete="off" placeholder="What can we help you find?" name="query" class="form-control">

--- a/jekyll/_sass/base/_sidebar.scss
+++ b/jekyll/_sass/base/_sidebar.scss
@@ -26,4 +26,9 @@
       text-decoration: none;
     }
   }
+
+  li {
+    padding-left: 1.0em;
+    text-indent: -0.5em;
+  }
 }


### PR DESCRIPTION
Use bootstrap columns and sidebar item indentation to optimize for smaller window sizes.

## Before
<img width="836" alt="screen shot 2016-07-22 at 4 01 51 pm" src="https://cloud.githubusercontent.com/assets/2172513/17073434/b14762ce-5025-11e6-8b5d-d4bb5731d86e.png">

## After
<img width="817" alt="screen shot 2016-07-22 at 4 01 30 pm" src="https://cloud.githubusercontent.com/assets/2172513/17073495/27d26416-5026-11e6-840d-81c059776a4d.png">
