### PR TITLE
Fix spacing in Campfire doc

### DIFF
--- a/jekyll/_docs/integrations/campfire.md
+++ b/jekyll/_docs/integrations/campfire.md
@@ -6,7 +6,7 @@ last_updated: May 11, 2016
 description: Campfire
 ---
 
-With the [Campfire](http://www.campfirenow.com)integration Airbrake sends new
+With the [Campfire](http://www.campfirenow.com) integration Airbrake sends new
 error notifications to the Campfire room of your choosing.
 
 ## Gathering the Pieces


### PR DESCRIPTION
Fixes spacing in description of Campfire doc.

### Before
![screen shot 2016-07-25 at 5 16 09 pm](https://cloud.githubusercontent.com/assets/2172513/17121898/a5093b78-528b-11e6-8c9f-1c25f3c591b6.png)

### After
![screen shot 2016-07-25 at 5 17 42 pm](https://cloud.githubusercontent.com/assets/2172513/17121905/bb85d65e-528b-11e6-97d3-902e9631be3d.png)
