### PR TITLE
Add new error to JIRA troubleshooting doc

### DIFF
--- a/jekyll/_docs/integrations/troubleshooting-jira-issues.md
+++ b/jekyll/_docs/integrations/troubleshooting-jira-issues.md
@@ -81,3 +81,12 @@ JIRA.
 This error occurs when your JIRA setup requires a field that Airbrake is not set
 up to provide. Please make the field that is mentioned in the error message
 optional in your JIRA settings, then test the integration again.
+
+# Error 6: Moved permanently
+
+>Jira integration could not connect. Error: 301 Moved Permanently - Please make sure the credentials are correct and try again.
+
+If you're seeing this error with **onDemand** JIRA but have double checked that
+you're using the correct credentials, then please check that you're using
+`https` instead of `http` for the **Server URL** field.
+


### PR DESCRIPTION
Adds new section for `301: Moved permanently` error to the JIRA troubleshooting help doc.

### Screenshot
<img width="546" alt="screen shot 2016-09-15 at 1 27 04 pm" src="https://cloud.githubusercontent.com/assets/2172513/18549742/3a136ed4-7b48-11e6-8850-b1b9d74493a5.png">
