### PR TITLE
Update link in global grouping doc

### DIFF
--- a/jekyll/_docs/airbrake-faq/how-do-global-error-types-work.md
+++ b/jekyll/_docs/airbrake-faq/how-do-global-error-types-work.md
@@ -15,7 +15,7 @@ dashboard up.  By setting the error class for these errors as a global class,
 the errors will be grouped together as they are delivered to our service.
 
 A full list of grouping options is available in our [grouping
-doc](/docs/airbrake-kb/configuring-error-grouping-settings).
+doc](https://airbrake.io/docs/airbrake-faq/configuring-error-grouping-settings/).
 
 ## Adding a global error class
 


### PR DESCRIPTION
- Update broken link in "What is global grouping" FAQ doc
- fixes #41 

### Screenshot
<img width="741" alt="screen shot 2016-09-22 at 5 44 04 pm" src="https://cloud.githubusercontent.com/assets/2172513/18770553/3f0008d6-80ec-11e6-83ff-4b1f072143b2.png">
