### PR TITLE
Add FAQ doc for backtrace links to GitHub

### DIFF
--- a/jekyll/_docs/airbrake-faq/backtrace-links-to-github.md
+++ b/jekyll/_docs/airbrake-faq/backtrace-links-to-github.md
@@ -1,0 +1,19 @@
+---
+layout: classic-docs
+title: Backtrace links to GitHub
+categories: [airbrake-faq]
+last_updated: Sept 27, 2016
+description: backtrace links to GitHub
+---
+
+## How do I get lines in my backtraces to link to GitHub?
+Airbrake creates links from lines in an error's backtrace by using the
+data supplied when you enable
+[deploy tracking](/docs/airbrake-faq/deploy-tracking) for your project.
+
+## Deploys create backtrace links
+When you use [deploy tracking](/docs/airbrake-faq/deploy-tracking), Airbrake
+will create helpful links out of lines in your backtraces that lead to the file,
+line, and revision in GitHub or GitLab.
+
+![backtrace link to github](/docs/assets/img/docs/airbrake/backtrace_link_to_github.png)


### PR DESCRIPTION
Add new doc in FAQ section for backtrace lines linking to corresponding GitHub file and line.

### Screenshot of new article
![screen shot 2016-09-27 at 3 11 49 pm](https://cloud.githubusercontent.com/assets/2172513/18893977/26765b12-84c5-11e6-86e1-4a374927a271.png)
