### PR TITLE
Fix code block whitespace color in JSON example

### DIFF
--- a/jekyll/assets/css/base16_dark.css
+++ b/jekyll/assets/css/base16_dark.css
@@ -2,7 +2,6 @@
 .highlight table pre { margin: 0; }
 .highlight, .highlight .w {
   color: #d0d0d0;
-  background-color: #151515;
 }
 .highlight .err {
   color: #151515;


### PR DESCRIPTION
- Fixes #47 
- Remove whitespace background color declaration for consistent whitespace color in code blocks

### Article
https://airbrake.io/docs/api-2/project-group-and-notice-api/

### Before
![project group and notice api - airbrake 2016-09-29 15-05-13](https://cloud.githubusercontent.com/assets/1079123/18953249/255bc676-8656-11e6-8b46-6ae7e5070d25.png)


### After
![screen shot 2016-10-03 at 6 25 33 pm](https://cloud.githubusercontent.com/assets/2172513/19059701/ce7df538-8996-11e6-811b-94d3cbfbd578.png)

