### PR TITLE
Remove stale section from email doc

### DIFF
--- a/jekyll/_docs/airbrake-faq/what-triggers-a-new-email.md
+++ b/jekyll/_docs/airbrake-faq/what-triggers-a-new-email.md
@@ -19,19 +19,6 @@ We currently review...
 - The controller that the action is in
 - The RAILS_ENV that was set when the error occurred
 
-## Error types that don't trigger emails
-
-We **explicitly do not** send emails for the following errors, as they are
-far too common and would just become noise:
-
-{% highlight ruby %}
-ActiveRecord::RecordNotFound
-CGI::Session::CookieStore::TamperedWithCookie
-ActionController::InvalidAuthenticityToken
-ActionController::RoutingError
-ActionController::UnknownAction
-{% endhighlight %}
-
 ## Resolved notices
 
 If you **resolve an error group** from within the application, don't worry -- if


### PR DESCRIPTION
This "Error types that don’t trigger emails" section is no longer correct. It was related to the now deprecated version 4 of our gem.

### Before
![screen shot 2016-12-06 at 11 16 42 am](https://cloud.githubusercontent.com/assets/2172513/20939904/97a99fc6-bba5-11e6-81b4-b82cc2db1eef.png)


### After
![screen shot 2016-12-06 at 11 16 30 am](https://cloud.githubusercontent.com/assets/2172513/20939909/9bd70c8c-bba5-11e6-934a-6028db05dbec.png)
