### PR TITLE
Use double quotes for JSON format

### DIFF
--- a/jekyll/_docs/airbrake-faq/deploy-tracking.md
+++ b/jekyll/_docs/airbrake-faq/deploy-tracking.md
@@ -79,7 +79,7 @@ USERNAME=$(whoami)
 
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d "{'environment':'${ENVIRONMENT}','username':'${USERNAME}','repository':'${REPOSITORY}','revision':'${REVISION}'}" \
+  -d '{"environment":"'${ENVIRONMENT}'","username":"'${USERNAME}'","repository":"'${REPOSITORY}'","revision":"'${REVISION}'"}' \
   "https://airbrake.io/api/v4/projects/${PROJECT_ID}/deploys?key=${PROJECT_KEY}"
 {% endhighlight %}
 


### PR DESCRIPTION
Fixes the bash script example.

### Before

<img width="886" alt="screen shot 2017-03-31 at 9 33 32 am" src="https://cloud.githubusercontent.com/assets/2172513/24560010/b06ac1ca-15f5-11e7-848a-892cbff6e3c0.png">


Running the script would result in error
```bash
➜ sh deploy_script.sh
{"error":"invalid character '\\'' looking for beginning of object key string"}
```

### After

<img width="793" alt="screen shot 2017-03-31 at 10 34 39 am" src="https://cloud.githubusercontent.com/assets/2172513/24562190/cf14322e-15fe-11e7-9c4e-708f4dc3a50c.png">

(Note that `"` are now used for the JSON input to the deploy command in the second to last line)

Now the deploy script will run properly:

```bash
➜ sh deploy_script.sh
{"id":"1918257576970612240"}%
```

Example of my `deploy_script.sh` (`PROJECT_ID` and `PROJECT_KEY` have been removed)
```bash
#!/bin/bash

PROJECT_ID=*******
PROJECT_KEY=*******
ENVIRONMENT=production
REPOSITORY=https://github.com/USERNAME/REPO
REVISION="$(git rev-parse HEAD)"
USERNAME=$(whoami)

curl -X POST \
  -H "Content-Type: application/json" \
  -d '{"environment":"'${ENVIRONMENT}'","username":"'${USERNAME}'","repository":"'${REPOSITORY}'","revision":"'${REVISION}'"}' \
  "https://airbrake.io/api/v4/projects/${PROJECT_ID}/deploys?key=${PROJECT_KEY}"
```

Screenshot of deploy in Airbrake:

<img width="522" alt="screen shot 2017-03-31 at 10 38 14 am" src="https://cloud.githubusercontent.com/assets/2172513/24562283/1656575c-15ff-11e7-86c4-b8fcca3e8b03.png">
