### PR TITLE
Update Heroku deploy docs

### DIFF
--- a/jekyll/_docs/airbrake-faq/deploy-tracking-troubleshooting.md
+++ b/jekyll/_docs/airbrake-faq/deploy-tracking-troubleshooting.md
@@ -33,27 +33,6 @@ icon in the top left corner of the error dashboard.
 
 **Resolve all errors on this project after a deploy** should be checked.
 
-# Heroku Deploy Hooks
-
-To implement Deploy Hooks on Heroku/Cedar stack, please use one of the following:
-
-{% highlight bash %}
-heroku addons:add deployhooks:http \
---url="http://airbrake.io/deploys.txt \
-?deploy[rails_env]=production \
-&api_key=AIRBRAKE_API_KEY \
-&deploy[local_username]={{user}} \
-&deploy[scm_revision]={{head_long}} \
-&deploy[scm_repository]=GITHUB_URL" # e.g. git@github.com:username/repo.git
-{% endhighlight %}
-
-{% highlight bash %}
-rake airbrake:heroku:add_deploy_notification
-{% endhighlight %}
-
-Be sure to provide the app name for the rake task if you have multiple Heroku
-apps configured. You can send it by specifying `ENV["HEROKU_APP"]`.
-
 # Capistrano Deploys
 If the notification of the deploy is not happening automatically when you do a
 capistrano deploy.

--- a/jekyll/_docs/airbrake-faq/deploy-tracking.md
+++ b/jekyll/_docs/airbrake-faq/deploy-tracking.md
@@ -133,6 +133,27 @@ If you use capistrano, you shouldn't have to run the rake command by hand.  The
 Airbrake notifier also includes a capistrano recipe that runs after
 `deploy:cleanup` which automatically triggers that rake task.
 
+# Heroku Deploy Hooks
+
+To implement Deploy Hooks on Heroku/Cedar stack, please use one of the following:
+
+{% highlight bash %}
+heroku addons:add deployhooks:http \
+--url="http://airbrake.io/deploys.txt \
+?deploy[rails_env]=production \
+&api_key=AIRBRAKE_API_KEY \
+&deploy[local_username]={{user}} \
+&deploy[scm_revision]={{head_long}} \
+&deploy[scm_repository]=GITHUB_URL" # e.g. git@github.com:username/repo.git
+{% endhighlight %}
+
+{% highlight bash %}
+rake airbrake:heroku:add_deploy_notification
+{% endhighlight %}
+
+Be sure to provide the app name for the rake task if you have multiple Heroku
+apps configured. You can send it by specifying `ENV["HEROKU_APP"]`.
+
 ## **DEPRECATED** Airbrake executable
 **DEPRECATION WARNING**: The information on the Airbrake executable is related
 to Airbrake v4 only and is no longer available in Airbrake v5.

--- a/jekyll/_docs/airbrake-faq/deploy-tracking.md
+++ b/jekyll/_docs/airbrake-faq/deploy-tracking.md
@@ -189,14 +189,3 @@ track_deploy(config) if notify_airbrake?(config)
 You can find more info on `config` and its variables in the <a
 href="https://support.cloud.engineyard.com/hc/en-us/articles/205407008-Use-Ruby-Deploy-Hooks"
 target="_blank">EngineYard doc on ruby deploy hooks</a>.
-
-## **DEPRECATED** Airbrake executable
-**DEPRECATION WARNING**: The information on the Airbrake executable is related
-to Airbrake v4 only and is no longer available in Airbrake v5.
-
-{% highlight bash %}
-airbrake deploy -k YOUR_API_KEY
-{% endhighlight %}
-
-For more information about the executable, please visit the Airbrake gem [wiki
-pages](https://github.com/airbrake/airbrake/wiki/Airbrake-executable).

--- a/jekyll/_docs/airbrake-faq/deploy-tracking.md
+++ b/jekyll/_docs/airbrake-faq/deploy-tracking.md
@@ -133,26 +133,34 @@ If you use capistrano, you shouldn't have to run the rake command by hand.  The
 Airbrake notifier also includes a capistrano recipe that runs after
 `deploy:cleanup` which automatically triggers that rake task.
 
-# Heroku Deploy Hooks
+## Heroku Deploy Hooks
 
-To implement Deploy Hooks on Heroku/Cedar stack, please use one of the following:
+To implement Deploy Hooks on Heroku, please use one of the following:
 
 {% highlight bash %}
 heroku addons:add deployhooks:http \
---url="http://airbrake.io/deploys.txt \
-?deploy[rails_env]=production \
-&api_key=AIRBRAKE_API_KEY \
-&deploy[local_username]={{user}} \
-&deploy[scm_revision]={{head_long}} \
-&deploy[scm_repository]=GITHUB_URL" # e.g. git@github.com:username/repo.git
+--url="https://airbrake.io/api/v3/projects/PROJECT_ID/heroku-deploys\
+?key=PROJECT_KEY\
+&environment=ENVIRONMENT\
+&repository=REPOSITORY_URL"
 {% endhighlight %}
 
 {% highlight bash %}
-rake airbrake:heroku:add_deploy_notification
+rake airbrake:install_heroku_deploy_hook
 {% endhighlight %}
 
 Be sure to provide the app name for the rake task if you have multiple Heroku
-apps configured. You can send it by specifying `ENV["HEROKU_APP"]`.
+apps configured. You can send it by setting the `HEROKU_APP` environment
+variable.
+
+The repository URL will default to the URL of the `origin` remote. The
+`REPOSITORY_URL` environment variable can be used to override this value.
+
+{% highlight bash %}
+export HEROKU_APP=your-heroku-app
+export REPOSITORY_URL=git@github.com:username/repo.git
+rake airbrake:install_heroku_deploy_hook
+{% endhighlight %}
 
 ## **DEPRECATED** Airbrake executable
 **DEPRECATION WARNING**: The information on the Airbrake executable is related

--- a/jekyll/_docs/airbrake-faq/deploy-tracking.md
+++ b/jekyll/_docs/airbrake-faq/deploy-tracking.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs
-title: Deploy Tracking
+title: Deploy tracking
 categories: [airbrake-faq]
-last_updated: Oct 24, 2016
+last_updated: Apr 28, 2017
 description: deploy tracking
 ---
 
@@ -127,16 +127,17 @@ environment.
 rake airbrake:deploy RAILS_ENV=development TO=development
 {% endhighlight %}
 
-## Capistrano
+### Capistrano
 
 If you use capistrano, you shouldn't have to run the rake command by hand.  The
 Airbrake notifier also includes a capistrano recipe that runs after
 `deploy:cleanup` which automatically triggers that rake task.
 
-## Heroku Deploy Hooks
+## Deploy tracking on Heroku
 
-To implement Deploy Hooks on Heroku, please use one of the following:
+To implement Deploy Hooks on Heroku, please use one of the following options.
 
+You can manually create the Deploy hook:
 {% highlight bash %}
 heroku addons:add deployhooks:http \
 --url="https://airbrake.io/api/v3/projects/PROJECT_ID/heroku-deploys\
@@ -145,6 +146,7 @@ heroku addons:add deployhooks:http \
 &repository=REPOSITORY_URL"
 {% endhighlight %}
 
+Or create it using rake:
 {% highlight bash %}
 rake airbrake:install_heroku_deploy_hook
 {% endhighlight %}
@@ -162,18 +164,7 @@ export REPOSITORY_URL=git@github.com:username/repo.git
 rake airbrake:install_heroku_deploy_hook
 {% endhighlight %}
 
-## **DEPRECATED** Airbrake executable
-**DEPRECATION WARNING**: The information on the Airbrake executable is related
-to Airbrake v4 only and is no longer available in Airbrake v5.
-
-{% highlight bash %}
-airbrake deploy -k YOUR_API_KEY
-{% endhighlight %}
-
-For more information about the executable, please visit the Airbrake gem [wiki
-pages](https://github.com/airbrake/airbrake/wiki/Airbrake-executable).
-
-## Usage Engine Yard Cloud
+## Deploy tracking on Engine Yard Cloud
 
 To notify Airbrake of your deploys to EngineYard cloud, you can use the
 following `deploy/after_restart.rb` script:
@@ -198,3 +189,14 @@ track_deploy(config) if notify_airbrake?(config)
 You can find more info on `config` and its variables in the <a
 href="https://support.cloud.engineyard.com/hc/en-us/articles/205407008-Use-Ruby-Deploy-Hooks"
 target="_blank">EngineYard doc on ruby deploy hooks</a>.
+
+## **DEPRECATED** Airbrake executable
+**DEPRECATION WARNING**: The information on the Airbrake executable is related
+to Airbrake v4 only and is no longer available in Airbrake v5.
+
+{% highlight bash %}
+airbrake deploy -k YOUR_API_KEY
+{% endhighlight %}
+
+For more information about the executable, please visit the Airbrake gem [wiki
+pages](https://github.com/airbrake/airbrake/wiki/Airbrake-executable).


### PR DESCRIPTION
Our Heroku deploy docs were outdated and in the wrong place. This PR moves the Heroku deploy section from the "Deploy tracking troubleshooting page" to the main "Deploy tracking" page, corrects the deploy hook URL and rake task, and adds info about setting the repository URL.

The diff is a little messy, so it's probably easier to review each commit one at a time.