### PR TITLE
Document high volume warnings

### DIFF
--- a/jekyll/_docs/airbrake-faq/what-triggers-a-new-email.md
+++ b/jekyll/_docs/airbrake-faq/what-triggers-a-new-email.md
@@ -32,3 +32,12 @@ because of further changes.
 
 Errors with a [severity](/docs/airbrake-faq/what-is-severity) of `debug`,
 `info`, `notice`, or `warning` will not trigger an email notification.
+
+## High volume warnings
+
+If you have enabled high volume warnings for your project you will be
+re-notified when an error's occurrences reach 10k, 100k, 200k, 300k, etc.
+High volume warnings can be enabled per project on your [user
+profile](https://airbrake.io/users/edit). High volume warnings help you keep
+tabs on which errors occur most in your project, and depending on frequency
+can be a useful indicator for larger issues.


### PR DESCRIPTION
This section documents high volume warnings and provides a link to
enable them in the user profile.

## Screenshot 

<img width="691" alt="screen shot 2017-06-19 at 11 34 09 am" src="https://user-images.githubusercontent.com/940237/27300066-4a0dea74-54e3-11e7-9933-aae9072c5d24.png">
