### PR TITLE
Make sure python example exception is uncaught

### DIFF
--- a/jekyll/_docs/installing-airbrake/sending-uncaught-python-exceptions-to-airbrake.md
+++ b/jekyll/_docs/installing-airbrake/sending-uncaught-python-exceptions-to-airbrake.md
@@ -44,10 +44,7 @@ if __name__ == '__main__':
 
     logging.debug('About to do f().')
 
-    try:
-        f()
-    except:
-        pass
+    f()
 {% endhighlight %}
 
 Having trouble? Email us at [support@airbrake.io](mailto:support@airbrake.io)


### PR DESCRIPTION
The python doc example for uncaught exceptions actually wraps an exception in such a way that it's *actually* caught. This fix properly triggers an uncaught exception.

@thompiler thanks for the headsup on this bug!