### PR TITLE
Fix the ruby proxy configuration example

### DIFF
--- a/jekyll/_docs/ruby/proxy-support.md
+++ b/jekyll/_docs/ruby/proxy-support.md
@@ -16,13 +16,13 @@ options in the initializer
 
 ### Configuring Airbrake V5 to use a proxy
 
-{% highlight ruby %}
+```ruby
 Airbrake.configure do |c|
   c.proxy = {
-    host: 'example.com'
-    port: 8080
-    user: 'user'
+    host: 'example.com',
+    port: 8080,
+    user: 'user',
     password: 'p4ssw0rd'
   }
 end
-{% endhighlight %}
+```


### PR DESCRIPTION
Adds missing commas to the proxy example, otherwise this isn't a
correct ruby hash.

Closes #174