### PR TITLE
Move logging airbrake error ids in Rack or Sinatra

### DIFF
--- a/jekyll/_docs/ruby/logging-airbrake-error-ids-in-rack-or-sinatra.md
+++ b/jekyll/_docs/ruby/logging-airbrake-error-ids-in-rack-or-sinatra.md
@@ -2,7 +2,7 @@
 layout: classic-docs
 title: Logging Airbrake error ids in Rack or Sinatra
 short-title: Logging error ids in Rack or Sinatra
-categories: [installing-airbrake]
+categories: [ruby]
 description: Logging Airbrake error ids in Rack or Sinatra
 ---
 


### PR DESCRIPTION
This doesn't have anything to do with installing Airbrake, and makes more sense in the ruby category.