### PR TITLE
Bump sourcemap limit

### DIFF
--- a/jekyll/_docs/features/private-sourcemaps.md
+++ b/jekyll/_docs/features/private-sourcemaps.md
@@ -83,7 +83,7 @@ We also support public sourcemaps please visit our [official airbrake-js repo](h
 
 #### Sourcemap file size limit
 
-Public and private sourcemaps have a file size limit of 4MB. Sourcemaps greater than 4MB will return a 400
+Public and private sourcemaps have a file size limit of 16MB. Sourcemaps greater than 16MB will return a 400
 
 ```
 {"code":400,"type":"Bad Request","message":"http: request body too large"}


### PR DESCRIPTION
The problem with sourcemap is that they can contain all source code which can be easily megabytes of data. Another problem is that with current implementation 4mb sourcemap file with source code requires ~30mb of RAM when it is unpacked and ready to be used. So to further increase the limit we need to optimize sourcemap representation which is not an easy task.