### PR TITLE
Fix CircleCI builds by specifying Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.0'
+ruby '~> 2.3.0'
 
 gem 'jekyll'
 gem 'html-proofer'

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  ruby:
+    version: 2.3.6
 test:
   post:
     - JEKYLL_ENV=staging bundle exec jekyll build --config jekyll/_config.yml,jekyll/_config_staging.yml --source jekyll --destination jekyll/_site/staging/docs/


### PR DESCRIPTION
An alternative option is to not specify the Ruby version in the Gemfile,
but this reduces unexpected outcomes, slightly.