### PR TITLE
Fix deprecated config name

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -22,7 +22,7 @@ collections:
 twitter_username: airbrake
 github_username:  airbrake
 
-gems:
+plugins:
   - jekyll-bootstrap-sass
 
 bootstrap:


### PR DESCRIPTION
This config name is due to be deprecated. Fixes this warning:

`Deprecation: The 'gems' configuration option has been renamed to
'plugins'. Please update your config file accordingly.`