### PR TITLE
Extract reusable javascript install sections

### DIFF
--- a/jekyll/_docs/installing-airbrake/airbrake-js/features.md
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/features.md
@@ -1,0 +1,7 @@
+## Features
+
+- Easy and flexible installation options including NPM, Bower and a public CDN
+- Send uncaught errors to Airbrake or manually using a try/catch
+- [Add custom parameters](https://github.com/airbrake/airbrake-js#filtering-errors) to your errors for more context
+- [Private sourcemap support](/docs/installing-airbrake/private-sourcemaps)
+- Control which errors you send with customizable filtering options

--- a/jekyll/_docs/installing-airbrake/airbrake-js/going-further.md
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/going-further.md
@@ -1,0 +1,13 @@
+## Going Further
+
+Installation and configuration is just the beginning. The [airbrake-js
+notifier](https://github.com/airbrake/airbrake-js) supports many other advanced uses and options including:
+
+- [adding extra details to errors](https://github.com/airbrake/airbrake-js#notice-annotations)
+- [sourcemaps for easy to parse backtraces](https://github.com/airbrake/airbrake-js#source-map)
+- [filtering errors](https://github.com/airbrake/airbrake-js#filtering-errors)
+- [specifying error severity](https://github.com/airbrake/airbrake-js#severity)
+- [adding custom reporters](https://github.com/airbrake/airbrake-js#custom-reporters)
+
+Please visit the [airbrake-js GitHub repo](https://github.com/airbrake/airbrake-js)
+for more usage and configuration examples.

--- a/jekyll/_docs/installing-airbrake/airbrake-js/installation.md
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/installation.md
@@ -1,0 +1,13 @@
+## Installation
+
+### Using npm
+
+```
+npm install airbrake-js
+```
+
+### Using Bower
+
+```
+bower install airbrake-js-client
+```

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
@@ -8,14 +8,9 @@ description: Installing Airbrake in a Javascript application
 
 ![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
 
-## Features
+{% include_relative airbrake-js/features.md %}
 
-- Easy and flexible installation options including NPM, Bower and a public CDN
-- Send uncaught errors to Airbrake or manually using a try/catch
-- [Add custom parameters](https://github.com/airbrake/airbrake-js#filtering-errors) to your errors for more context
-- [Private sourcemap support](/docs/installing-airbrake/private-sourcemaps)
-- Control which errors you send with customizable filtering options
-- Support for:
+## Supported frameworks
   - [AngularJS](/docs/installing-airbrake/installing-airbrake-in-an-angularjs-app/)
   - [Angular 2](https://github.com/airbrake/airbrake-js/tree/master/examples/angular-2)
   - [Backbone.js](https://github.com/airbrake/airbrake-js/wiki/Using-Airbrake-with-Backbone.js)
@@ -28,22 +23,7 @@ description: Installing Airbrake in a Javascript application
   - [React](https://github.com/airbrake/airbrake-js/tree/master/examples/react)
   - [RequireJS](https://github.com/airbrake/airbrake-js/tree/master/examples/requirejs)
 
-## Installation
-
-#### *Visit our [official GitHub repository](https://github.com/airbrake/airbrake-js) for full installation instructions and configuration options.*
-
-The notifier is built using a
-[standalone browserify build](http://www.forbeslindesay.co.uk/post/46324645400/standalone-browserify-builds)
-and can be used with:
-
-- [RequireJS](https://github.com/airbrake/airbrake-js/tree/master/examples/requirejs).
-- [Global/Window](https://github.com/airbrake/airbrake-js/tree/master/examples/legacy).
-
-We include the full source code with the package, so you can use
-[Browserify](https://github.com/airbrake/airbrake-js/tree/master/examples/browserify) too.
-
-If you prefer not to host the library yourself,
-[airbrake-js is available on the excellent cdnjs CDN](https://cdnjs.com/libraries/airbrake-js).
+{% include_relative airbrake-js/installation.md %}
 
 ## Basic Usage
 
@@ -85,4 +65,4 @@ startApp = airbrake.wrap(startApp);
 startApp();
 ```
 
-#### *Visit our [official GitHub repository](https://github.com/airbrake/airbrake-js) for more information.*
+{% include_relative airbrake-js/going-further.md %}

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-angularjs-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-angularjs-app.md
@@ -7,28 +7,8 @@ description: Installing Airbrake in an AngularJS application
 ---
 
 ![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
-
-## Features
-
-- Easy and flexible installation options including NPM, Bower and a public CDN
-- Send uncaught errors to Airbrake or manually using a try/catch
-- [Add custom parameters](https://github.com/airbrake/airbrake-js#filtering-errors) to your errors for more context
-- [Private sourcemap support](/docs/installing-airbrake/private-sourcemaps)
-- Control which errors you send with customizable filtering options
-
-## Installation
-
-### Using npm
-
-```
-npm install airbrake-js
-```
-
-### Using Bower
-
-```
-bower install airbrake-js-client
-```
+{% include_relative airbrake-js/features.md %}
+{% include_relative airbrake-js/installation.md %}
 
 ## Configuration
 
@@ -62,16 +42,4 @@ angular
   });
 ```
 
-## Going Further
-
-Installation and configuration is just the beginning. The [airbrake-js
-notifier](https://github.com/airbrake/airbrake-js) supports many other advanced uses and options including:
-
-- [adding extra details to errors](https://github.com/airbrake/airbrake-js#notice-annotations)
-- [sourcemaps for easy to parse backtraces](https://github.com/airbrake/airbrake-js#source-map)
-- [filtering errors](https://github.com/airbrake/airbrake-js#filtering-errors)
-- [specifying error severity](https://github.com/airbrake/airbrake-js#severity)
-- [adding custom reporters](https://github.com/airbrake/airbrake-js#custom-reporters)
-
-Please visit the [airbrake-js GitHub repo](https://github.com/airbrake/airbrake-js)
-for more usage and configuration examples.
+{% include_relative airbrake-js/going-further.md %}

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-angularjs-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-angularjs-app.md
@@ -7,7 +7,9 @@ description: Installing Airbrake in an AngularJS application
 ---
 
 ![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
+
 {% include_relative airbrake-js/features.md %}
+
 {% include_relative airbrake-js/installation.md %}
 
 ## Configuration

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-express-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-express-app.md
@@ -7,28 +7,8 @@ description: Installing Airbrake in an Express application
 ---
 
 ![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
-
-## Features
-
-- Easy and flexible installation options including NPM, Bower and a public CDN
-- Send uncaught errors to Airbrake or manually using a try/catch
-- [Add custom parameters](https://github.com/airbrake/airbrake-js#filtering-errors) to your errors for more context
-- [Private sourcemap support](/docs/installing-airbrake/private-sourcemaps)
-- Control which errors you send with customizable filtering options
-
-## Installation
-
-### Using npm
-
-```
-npm install airbrake-js
-```
-
-### Using Bower
-
-```
-bower install airbrake-js-client
-```
+{% include_relative airbrake-js/features.md %}
+{% include_relative airbrake-js/installation.md %}
 
 ## Configuration
 
@@ -72,16 +52,4 @@ app.listen(3000, function () {
 })
 ```
 
-## Going Further
-
-Installation and configuration is just the beginning. The [airbrake-js
-notifier](https://github.com/airbrake/airbrake-js) supports many other advanced uses and options including:
-
-- [adding extra details to errors](https://github.com/airbrake/airbrake-js#notice-annotations)
-- [sourcemaps for easy to parse backtraces](https://github.com/airbrake/airbrake-js#source-map)
-- [filtering errors](https://github.com/airbrake/airbrake-js#filtering-errors)
-- [specifying error severity](https://github.com/airbrake/airbrake-js#severity)
-- [adding custom reporters](https://github.com/airbrake/airbrake-js#custom-reporters)
-
-Please visit the [airbrake-js GitHub repo](https://github.com/airbrake/airbrake-js)
-for more usage and configuration examples.
+{% include_relative airbrake-js/going-further.md %}

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-express-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-express-app.md
@@ -7,7 +7,9 @@ description: Installing Airbrake in an Express application
 ---
 
 ![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
+
 {% include_relative airbrake-js/features.md %}
+
 {% include_relative airbrake-js/installation.md %}
 
 ## Configuration

--- a/jekyll/_includes/airbrake-js-going-further.md
+++ b/jekyll/_includes/airbrake-js-going-further.md
@@ -1,0 +1,13 @@
+## Going Further
+
+Installation and configuration is just the beginning. The [airbrake-js
+notifier](https://github.com/airbrake/airbrake-js) supports many other advanced uses and options including:
+
+- [adding extra details to errors](https://github.com/airbrake/airbrake-js#notice-annotations)
+- [sourcemaps for easy to parse backtraces](https://github.com/airbrake/airbrake-js#source-map)
+- [filtering errors](https://github.com/airbrake/airbrake-js#filtering-errors)
+- [specifying error severity](https://github.com/airbrake/airbrake-js#severity)
+- [adding custom reporters](https://github.com/airbrake/airbrake-js#custom-reporters)
+
+Please visit the [airbrake-js GitHub repo](https://github.com/airbrake/airbrake-js)
+for more usage and configuration examples.


### PR DESCRIPTION
We had some repeating information in our JS docs. This extracts the
sections that are reusable.

There are a lot of javascript frameworks and including these partials should make it simpler to add new JS installation instructions in the future.