### PR TITLE
Remove space from "Angular JS"

### DIFF
--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
@@ -16,7 +16,7 @@ description: Installing Airbrake in a Javascript application
 - [Private sourcemap support](/docs/installing-airbrake/private-sourcemaps)
 - Control which errors you send with customizable filtering options
 - Support for:
-  - [AngularJS](/docs/installing-airbrake/installing-airbrake-in-an-angular-js-app/)
+  - [AngularJS](/docs/installing-airbrake/installing-airbrake-in-an-angularjs-app/)
   - [Angular 2](https://github.com/airbrake/airbrake-js/tree/master/examples/angular-2)
   - [Backbone.js](https://github.com/airbrake/airbrake-js/wiki/Using-Airbrake-with-Backbone.js)
   - [Bower](https://github.com/airbrake/airbrake-js/tree/master/examples/bower-wiredep)

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-angularjs-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-an-angularjs-app.md
@@ -1,9 +1,9 @@
 ---
 layout: classic-docs
-title: Installing Airbrake in an Angular JS application
-short-title: Angular JS
+title: Installing Airbrake in an AngularJS application
+short-title: AngularJS
 categories: [installing-airbrake]
-description: Installing Airbrake in an Angular JS application
+description: Installing Airbrake in an AngularJS application
 ---
 
 ![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)


### PR DESCRIPTION
I realized this after the fact but it's `AngularJS` not `Angular JS`.