### PR TITLE
Add Vue.js install doc

### DIFF
--- a/jekyll/_docs/installing-airbrake/airbrake-js/vuejs/config.md
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/vuejs/config.md
@@ -1,0 +1,24 @@
+### Vue.js error handler
+
+You can start reporting errors from your Vue.js app by configuring an
+[`errorHandler`](https://vuejs.org/v2/api/#errorHandler) that uses an
+`AirbrakeClient` initialized with your `projectId` and `projectKey`.
+
+```js
+import AirbrakeClient from 'airbrake-js';
+
+var airbrake = new AirbrakeClient({
+  projectId: 1,
+  projectKey: 'FIXME'
+});
+
+Vue.config.errorHandler = function (err, vm, info) {
+  airbrake.notify({
+    error: err,
+    params: {info: info}
+  });
+}
+```
+
+For more information on Vue.js error handling, read the [`errorHandler`
+documentation](https://vuejs.org/v2/api/#errorHandler).

--- a/jekyll/_docs/installing-airbrake/airbrake-js/vuejs/fetch_config
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/vuejs/fetch_config
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Fetch the README.md file from the Vue.js example app
+
+curl 'https://raw.githubusercontent.com/airbrake/airbrake-js/master/examples/vuejs/README.md' \
+-o config.md

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
@@ -23,6 +23,7 @@ description: Installing Airbrake in a Javascript application
   - [React](https://github.com/airbrake/airbrake-js/tree/master/examples/react)
   - [Redux](/docs/installing-airbrake/installing-airbrake-in-a-redux-app/)
   - [RequireJS](https://github.com/airbrake/airbrake-js/tree/master/examples/requirejs)
+  - [Vue.js](/docs/installing-airbrake/installing-airbrake-in-a-vuejs-app/)
 
 {% include_relative airbrake-js/installation.md %}
 

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-vuejs-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-vuejs-app.md
@@ -1,0 +1,19 @@
+---
+layout: classic-docs
+title: Installing Airbrake in a Vue.js application
+short-title: Vue.js
+categories: [installing-airbrake]
+description: Installing Airbrake in a Vue.js application
+---
+
+![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
+
+{% include_relative airbrake-js/features.md %}
+
+{% include_relative airbrake-js/installation.md %}
+
+## Configuration
+
+{% include_relative airbrake-js/vuejs/config.md %}
+
+{% include_relative airbrake-js/going-further.md %}


### PR DESCRIPTION
This adds install instructions to report errors from a Vue.js project.
The configuration section was fetched from the Vue.js example project in
the airbrake-js repo.