### PR TITLE
Add RequireJS installation instructions

### DIFF
--- a/jekyll/_docs/installing-airbrake/airbrake-js/requirejs/app.js
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/requirejs/app.js
@@ -1,0 +1,23 @@
+require.config({
+  paths: {
+    airbrakeJs: 'node_modules/airbrake-js/dist'
+  }
+});
+
+require(['airbrakeJs/client'], function (AirbrakeClient) {
+  var airbrake = new AirbrakeClient({
+    projectId: 1,
+    projectKey: 'FIXME'
+  });
+
+  try {
+    throw new Error('hello from Require.js');
+  } catch (err) {
+    promise = airbrake.notify(err);
+    promise.then(function(notice) {
+      console.log('notice id:', notice.id);
+    }, function(err) {
+      console.log('airbrake failed:', err);
+    });
+  }
+});

--- a/jekyll/_docs/installing-airbrake/airbrake-js/requirejs/fetch_app_js
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/requirejs/fetch_app_js
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Fetch the app.js file from the example RequireJS app
+
+curl 'https://raw.githubusercontent.com/airbrake/airbrake-js/master/examples/requirejs/app.js' \
+  -o app.js

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
@@ -22,7 +22,7 @@ description: Installing Airbrake in a Javascript application
   - [Rails](https://github.com/airbrake/airbrake-js/tree/master/examples/rails)
   - [React](https://github.com/airbrake/airbrake-js/tree/master/examples/react)
   - [Redux](/docs/installing-airbrake/installing-airbrake-in-a-redux-app/)
-  - [RequireJS](https://github.com/airbrake/airbrake-js/tree/master/examples/requirejs)
+  - [RequireJS](/docs/installing-airbrake/installing-airbrake-in-a-requirejs-app/)
 
 {% include_relative airbrake-js/installation.md %}
 

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-requirejs-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-requirejs-app.md
@@ -1,0 +1,26 @@
+---
+layout: classic-docs
+title: Installing Airbrake in a RequireJS application
+short-title: RequireJS
+categories: [installing-airbrake]
+description: Installing Airbrake in a RequireJS application
+---
+
+![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
+
+{% include_relative airbrake-js/features.md %}
+
+{% include_relative airbrake-js/installation.md %}
+
+## Configuration
+
+To report errors from your RequireJS app you configure an `AirbrakeClient` with
+your `projectId` and `projectKey` and report errors with the `notify` function.
+Here is an example from our
+[RequireJS example app](https://github.com/airbrake/airbrake-js/tree/master/examples/requirejs):
+
+```js
+{% include_relative airbrake-js/requirejs/app.js %}
+```
+
+{% include_relative airbrake-js/going-further.md %}


### PR DESCRIPTION
Instructions on how to report errors from your RequireJS app.
The example code was fetched from the RequireJS example app in the airbrake-js repo.
The example code can be re-fetched and updated with the helper script when needed.