### PR TITLE
Add Bower install doc

### DIFF
--- a/jekyll/_docs/installing-airbrake/airbrake-js/bower/app.js
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/bower/app.js
@@ -1,0 +1,19 @@
+function start() {
+  var airbrake = new airbrakeJs.Client({
+    projectId: 1,
+    projectKey: 'FIXME'
+  });
+
+  try {
+    throw new Error('hello from Bower+Wiredep');
+  } catch (err) {
+    promise = airbrake.notify(err);
+    promise.then(function(notice) {
+      console.log('notice id:', notice.id);
+    }, function(err) {
+      console.log('airbrake failed:', err);
+    });
+  }
+}
+
+start();

--- a/jekyll/_docs/installing-airbrake/airbrake-js/bower/fetch_app_js
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/bower/fetch_app_js
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Fetch the app.js file from the example Bower app
+
+curl 'https://raw.githubusercontent.com/airbrake/airbrake-js/master/examples/bower-wiredep/app.js' \
+  -o app.js

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-bower-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-bower-app.md
@@ -1,0 +1,26 @@
+---
+layout: classic-docs
+title: Installing Airbrake in a Bower application
+short-title: Bower
+categories: [installing-airbrake]
+description: Installing Airbrake in a Bower application
+---
+
+![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
+
+{% include_relative airbrake-js/features.md %}
+
+{% include_relative airbrake-js/installation.md %}
+
+## Configuration
+
+To report errors from your Bower app you configure an `airbrakeJs.Client` with
+your `projectId` and `projectKey` and report errors with the `notify` function.
+Here is an example from our
+[Bower example app](https://github.com/airbrake/airbrake-js/tree/master/examples/bower-wiredep):
+
+```js
+{% include_relative airbrake-js/bower/app.js %}
+```
+
+{% include_relative airbrake-js/going-further.md %}

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
@@ -14,7 +14,7 @@ description: Installing Airbrake in a Javascript application
   - [AngularJS](/docs/installing-airbrake/installing-airbrake-in-an-angularjs-app/)
   - [Angular 2](https://github.com/airbrake/airbrake-js/tree/master/examples/angular-2)
   - [Backbone.js](https://github.com/airbrake/airbrake-js/wiki/Using-Airbrake-with-Backbone.js)
-  - [Bower](https://github.com/airbrake/airbrake-js/tree/master/examples/bower-wiredep)
+  - [Bower](/docs/installing-airbrake/installing-airbrake-in-a-bower-app/)
   - [Browserify](https://github.com/airbrake/airbrake-js/tree/master/examples/browserify)
   - [Express](/docs/installing-airbrake/installing-airbrake-in-an-express-app/)
   - [hapi.js](/docs/installing-airbrake/installing-airbrake-in-a-hapijs-app/)


### PR DESCRIPTION
Adds instructions on how to reporting errors from your Bower app.
The example code was fetched from the Bower example app in the airbrake-js repo.
The example code can be re-fetched and updated with the helper script when needed.