### PR TITLE
Add Browserify install doc

### DIFF
--- a/jekyll/_docs/installing-airbrake/airbrake-js/browserify/app.js
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/browserify/app.js
@@ -1,0 +1,21 @@
+function start() {
+  var AirbrakeClient = require('airbrake-js');
+
+  var airbrake = new AirbrakeClient({
+    projectId: 1,
+    projectKey: 'FIXME'
+  });
+
+  try {
+    throw new Error('hello from Browserify');
+  } catch (err) {
+    promise = airbrake.notify(err);
+    promise.then(function(notice) {
+      console.log('notice id:', notice.id);
+    }, function(err) {
+      console.log('airbrake failed:', err);
+    });
+  }
+}
+
+start();

--- a/jekyll/_docs/installing-airbrake/airbrake-js/browserify/fetch_app_js
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/browserify/fetch_app_js
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Fetch the app.js file from the example Bower app
+
+curl 'https://raw.githubusercontent.com/airbrake/airbrake-js/master/examples/browserify/app.js' \
+  -o app.js

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-browserify-app.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-browserify-app.md
@@ -1,0 +1,26 @@
+---
+layout: classic-docs
+title: Installing Airbrake in a Browserify application
+short-title: Browserify
+categories: [installing-airbrake]
+description: Installing Airbrake in a Browserify application
+---
+
+![](https://s3.amazonaws.com/document-resources/jsbrakeman.png)
+
+{% include_relative airbrake-js/features.md %}
+
+{% include_relative airbrake-js/installation.md %}
+
+## Configuration
+
+To report errors from your Browserify app you configure an `AirbrakeClient` with
+your `projectId` and `projectKey` and report errors with the `notify` function.
+Here is an example from our
+[Browserify example app](https://github.com/airbrake/airbrake-js/tree/master/examples/browserify):
+
+```js
+{% include_relative airbrake-js/browserify/app.js %}
+```
+
+{% include_relative airbrake-js/going-further.md %}

--- a/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
+++ b/jekyll/_docs/installing-airbrake/installing-airbrake-in-a-javascript-application.md
@@ -15,7 +15,7 @@ description: Installing Airbrake in a Javascript application
   - [Angular 2](https://github.com/airbrake/airbrake-js/tree/master/examples/angular-2)
   - [Backbone.js](https://github.com/airbrake/airbrake-js/wiki/Using-Airbrake-with-Backbone.js)
   - [Bower](https://github.com/airbrake/airbrake-js/tree/master/examples/bower-wiredep)
-  - [Browserify](https://github.com/airbrake/airbrake-js/tree/master/examples/browserify)
+  - [Browserify](/docs/installing-airbrake/installing-airbrake-in-a-browserify-app/)
   - [Express](/docs/installing-airbrake/installing-airbrake-in-an-express-app/)
   - [hapi.js](/docs/installing-airbrake/installing-airbrake-in-a-hapijs-app/)
   - [Legacy](https://github.com/airbrake/airbrake-js/tree/master/examples/legacy)


### PR DESCRIPTION
Adds installation instructions to report errors from a Browserify app.
Fetches the example code from airbrake-js.