### PR TITLE
Fix private sourcemap link

### DIFF
--- a/jekyll/_docs/installing-airbrake/airbrake-js/features.md
+++ b/jekyll/_docs/installing-airbrake/airbrake-js/features.md
@@ -3,5 +3,5 @@
 - Easy and flexible installation options including NPM, Bower and a public CDN
 - Send uncaught errors to Airbrake or manually using a try/catch
 - [Add custom parameters](https://github.com/airbrake/airbrake-js#filtering-errors) to your errors for more context
-- [Private sourcemap support](/docs/installing-airbrake/private-sourcemaps)
+- [Private sourcemap support](/docs/features/private-sourcemaps)
 - Control which errors you send with customizable filtering options


### PR DESCRIPTION
Doc https://airbrake.io/docs/installing-airbrake/installing-airbrake-in-a-javascript-application/ has a link to https://airbrake.io/docs/installing-airbrake/private-sourcemaps, but it should be https://airbrake.io/docs/features/private-sourcemaps/