### PR TITLE
Simplify rake & capistrano deploy documentation

### DIFF
--- a/jekyll/_docs/features/deploy-tracking.md
+++ b/jekyll/_docs/features/deploy-tracking.md
@@ -99,64 +99,13 @@ The API returns `201 Created` status code on success.
 
 ## Deploy tracking with `rake airbrake:deploy`
 
-Deploy tracking requires the latest airbrake notifier. Be sure you have the
-latest version installed from [github](https://github.com/airbrake/airbrake).
+The airbrake Ruby gem provides a convenient
+[Rake task to track deploys](https://github.com/airbrake/airbrake#rake-task).
 
-Once installed, your application will have a new rake task, here are some
-examples.
+## Deploy tracking with Capistrano
 
-To Mark all Errors as Resolved for the `production` environment you can use the
-following command:
-
-{% highlight bash %}
-rake airbrake:deploy TO=production
-{% endhighlight %}
-
-To Mark all Errors as Resolved for a **specific environment**, use the
-following format:
-
-{% highlight bash %}
-rake airbrake:deploy RAILS_ENV=<rails environment> TO=rails environment
-{% endhighlight %}
-
-For example the following rake command will track a deploy to the `development`
-environment.
-
-{% highlight bash %}
-rake airbrake:deploy RAILS_ENV=development TO=development
-{% endhighlight %}
-
-### Capistrano
-
-If you use Capistrano, you shouldn't have to run the rake command by hand. The
-Airbrake notifier also includes a Capistrano recipe that runs after
-`deploy:cleanup` which automatically triggers that rake task.
-
-In order to configure deploy tracking with Capistrano simply `require` our
-integration in your Capfile:
-
-```ruby
-# Capfile
-require 'airbrake/capistrano'
-```
-
-If you use Capistrano 3, define the `after :finished` hook, which executes the
-deploy notification task (Capistrano 2 doesn't require this step).
-
-```ruby
-# config/deploy.rb
-namespace :deploy do
-  after :finished, 'airbrake:deploy'
-end
-```
-
-If you version your application, you can set the `:app_version` variable in
-`config/deploy.rb`, so that information will be attached to your deploy.
-
-```ruby
-# config/deploy.rb
-set :app_version, '1.2.3'
-```
+The airbrake Ruby gem provides a convenient
+[Capistrano recipe to track deploys](https://github.com/airbrake/airbrake#capistrano).
 
 ## Deploy tracking on Heroku
 


### PR DESCRIPTION
Deploy tracking doesn't need a notifier, but the airbrake Ruby gem
notifier provides a rake task and Capistrano recipe, for convenience.
Link to the gem documentation for each, to avoid providing potentially
out-of-date or duplicate docs.