### PR TITLE
Add troubleshooting for error/deploy association

### DIFF
--- a/jekyll/_docs/features/deploy-tracking-troubleshooting.md
+++ b/jekyll/_docs/features/deploy-tracking-troubleshooting.md
@@ -28,6 +28,25 @@ can be disabled. It can be found on your project's settings page.
 
 ![resolve all checkbox](/docs/assets/img/docs/airbrake/resolve_all_checkbox.png)
 
+# Errors are not associated with deploys, and vice-versa
+
+Deploys are considered 'active' until a new deploy to the same environment
+(e.g. 'production') replaces it. Airbrake associates new errors to the active
+deploy of the same environment.
+
+_If_ you use the optional [App Version](/docs/features/app-versions) Airbrake
+feature, Airbrake will only associate errors and deploys that have a matching
+`version` string, in addition to a matching `environment`.
+
+Therefore, common solutions to errors and deploys not being associated are:
+
+- Ensure that the `environment` string is identical on the errors and the
+  deploys.
+- If you _do not_ wish to use the [App Version](/docs/features/app-versions)
+  behavior, do not specify `version` with your errors or deploys.
+- If you _do_ wish to use the [App Version](/docs/features/app-versions)
+  behavior, ensure the `version` of your errors and deploys are consistent.
+
 # Capistrano Deploys
 If the notification of the deploy is not happening automatically when you do a
 capistrano deploy, you may need to add `require 'airbrake/capistrano'` to your


### PR DESCRIPTION
This helps explain how deploy tracking an app versioning works, and
offers commonly seen solutions to when errors and deploys are not
associated.