### PR TITLE
Don't show links to the grouping docs

### DIFF
--- a/jekyll/_docs/airbrake-faq/configuring-error-grouping-settings.md
+++ b/jekyll/_docs/airbrake-faq/configuring-error-grouping-settings.md
@@ -1,7 +1,6 @@
 ---
 layout: classic-docs
 title: Configuring error grouping settings
-categories: [airbrake-faq]
 description: configuring error grouping settings for your project
 ---
 

--- a/jekyll/_docs/airbrake-faq/how-do-global-error-types-work.md
+++ b/jekyll/_docs/airbrake-faq/how-do-global-error-types-work.md
@@ -1,7 +1,6 @@
 ---
 layout: classic-docs
 title: Global error grouping
-categories: [airbrake-faq]
 description: Global error grouping
 ---
 


### PR DESCRIPTION
Docs are still available at the old URLs, but links to the pages are no longer shown,