### PR TITLE
Fix the environment description

### DIFF
--- a/jekyll/_docs/airbrake-faq/what-triggers-a-new-email.md
+++ b/jekyll/_docs/airbrake-faq/what-triggers-a-new-email.md
@@ -11,11 +11,12 @@ error entirely, or just another occurrence of an error we've previously seen.
 We currently review...
 
 - The error class of the error
-- The error message of the error with data values extracted
-(see [structured logging](/docs/features/structured-logging))
+- The error message of the error with data values extracted (see [structured
+  logging](/docs/features/structured-logging))
 - The file in which the error occurred
 - The line number at which the error occurred
-- The `RAILS_ENV` that was set when the error occurred
+- The `environment` where the error occurred (see
+  [environments](/docs/airbrake-faq/configuring-project-environments/))
 
 ## What is a notification?
 A notification can be:


### PR DESCRIPTION
This doc described `environment` in a way that is only relevant to Rails
projects. This fixes it, describing it for all project types.