### PR TITLE
faq/rejected-errors: delete information about AirbrakeNotice

### DIFF
--- a/jekyll/_docs/airbrake-faq/rejected-errors.md
+++ b/jekyll/_docs/airbrake-faq/rejected-errors.md
@@ -25,27 +25,11 @@ by:
 [POST data fields](https:/airbrake.io/docs/api/#post-data-fields-v3)
 - **XML**: as described in our [XML API doc](/docs/api-2/notifier-api-v23)
 
-## Rejections in the dashboard
-
-### Graphed rejections
+## Graphed rejections
 You can view rejected error trends in your project overview graph.
-
-### Placeholder exceptions`AirbrakeNotice`
-Rejections that are due to invalid error format are also displayed in your
-error groups list and appear as `AirbrakeNotice` placeholder exceptions that
-provide as much information as possible. These placeholders let you know that
-your Airbrake notifier library couldn't parse an error into the correct format.
 
 ## Getting rejections?
 
-### Experimental Airbrake notifier
-It's common to see error rejections when using an experimental or unsupported
-Airbrake notifiers. You can use the information provided by the `AirbrakeNotice`
-placeholder to troubleshoot your notifier. `AirbrakeNotice` placeholders can be a
-valuable debugging asset when developing a new Airbrake Notifier and reporting
-GitHub issues.
-
-### Official Airbrake notifier
 Rejections are less likely with official and widely adopted Airbrake notifiers.
 However, if errors sent by your Notifier are consistently getting rejected,
 please help improve the Airbrake notifier you are using by creating a GitHub


### PR DESCRIPTION
The backend doesn't generate this anymore, so this information is outdated.