### PR TITLE
Remove parentheses from templates

### DIFF
--- a/jekyll/_layouts/classic-category.html
+++ b/jekyll/_layouts/classic-category.html
@@ -12,7 +12,7 @@ layout: classic-docs
 {% endif %}
 
 {% for doc in site.docs %}
-  {% if (doc.categories contains category) and (doc.slug != page.slug ) %}
+  {% if doc.categories contains category and doc.slug != page.slug %}
     {% if doc.short-title %}
       <li><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.short-title }}</a></li>
     {% else %}

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -12,7 +12,7 @@ layout: classic-docs
   <ul class="list-unstyled">
     {% assign docs_found = 0 %}
     {% for doc in site.docs %}
-      {% if (doc.categories contains category.slug) and (doc.slug != category.index) %}
+      {% if doc.categories contains category.slug and doc.slug != category.index %}
         {% assign docs_found = docs_found | plus: 1 %}
         {% if docs_found < 4 %}
           {% if doc.short-title %}


### PR DESCRIPTION
Liquid does not support parentheses within tags.

Fixes:
```
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found comparison in "(doc.categories contains category) and (doc.slug != page.slug )" in /_layouts/classic-category.html
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found comparison in "(doc.categories contains category) and (doc.slug != page.slug )" in /_layouts/classic-category.html
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found comparison in "(doc.categories contains category) and (doc.slug != page.slug )" in /_layouts/classic-category.html
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found comparison in "(doc.categories contains category) and (doc.slug != page.slug )" in /_layouts/classic-category.html
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found comparison in "(doc.categories contains category) and (doc.slug != page.slug )" in /_layouts/classic-category.html
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found comparison in "(doc.categories contains category) and (doc.slug != page.slug )" in /_layouts/classic-category.html
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found comparison in "(doc.categories contains category) and (doc.slug != page.slug )" in /_layouts/classic-category.html
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found comparison in "(doc.categories contains category.slug) and (doc.slug != category.index)" in index.html
```