### PR TITLE
Remove empty categories from categories.yml

### DIFF
--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -18,14 +18,6 @@
   slug: airbrake-faq
   index: airbrake-faq
 
-- name: "Airbrake: Android & iOS"
-  slug: airbrake-android-ios
-  index: airbrake-android-ios
-
-- name: "Alternate Airbrake Plugins"
-  slug: alternate-airbrake-plugins
-  index: alternate-airbrake-plugins
-
 - name: "Billing"
   slug: billing
   index: billing


### PR DESCRIPTION
These categories have not been used since 9369fce8839de5eedd772c27f993ea513cd7934a, but they currently remain in the sidebar. This removes them completely.