### PR TITLE
Update JIRA docs

### DIFF
--- a/jekyll/_docs/integrations/jira.md
+++ b/jekyll/_docs/integrations/jira.md
@@ -37,7 +37,9 @@ party.
 - API token: your-api-token
 - Project key: EXAMPLE
 
-You can create a new API token [here](https://id.atlassian.com/manage/api-tokens).
+**Please ensure the API token is created on the account with the same email
+address as provided in JIRA integration on Airbrake.** You can create a new API
+token [here](https://id.atlassian.com/manage/api-tokens).
 
 ### JIRA standalone integration:
 

--- a/jekyll/_docs/integrations/troubleshooting-jira-issues.md
+++ b/jekyll/_docs/integrations/troubleshooting-jira-issues.md
@@ -84,7 +84,9 @@ your JIRA username. You can find your JIRA username in your profile page by
 clicking your avatar in JIRA.
 
 For JIRA onDemand you should be using **Email** and **API token** instead of
-username and password so please make sure you're using the correct email.
+username and password so please make sure you're using the correct email. Also,
+please ensure the API token is created on the account with the same email
+address as provided in JIRA integration on Airbrake.
 
 ### Correct: specifies the username
 ![jira issues correct username](/docs/assets/img/docs/integrations/jira_issues_correct_username.png)


### PR DESCRIPTION
When using JIRA onDemand integration **Email** and **API token** should
be used to basic auth. It's important to create the API token on the
account with the same email address as provided in JIRA integration on
Airbrake.