### PR TITLE
Clarify custom URLs and server side sourcemaps

### DIFF
--- a/jekyll/_docs/features/private-sourcemaps.md
+++ b/jekyll/_docs/features/private-sourcemaps.md
@@ -102,3 +102,13 @@ Public and private sourcemaps have a file size limit of 32MB. Sourcemaps greater
   download it since, again, it's localhost
 - Airbrake then finally checks if you manually uploaded that file using this
   **private sourcemap feature**
+
+## Server side sourcemaps
+
+For server side sourcemaps (eg: for Node.js apps), please use the following
+steps:
+1. Upload sourcemap to Airbrake using our [Private Sourcemaps
+   feature](/docs/features/private-sourcemaps/#uploading-sourcemaps)
+2. Link the minified JS files to the corresponding sourcemap using the [custom
+   sourcemap URLs](/docs/features/public-sourcemaps/#custom-sourcemap-urls)
+   feature

--- a/jekyll/_docs/features/public-sourcemaps.md
+++ b/jekyll/_docs/features/public-sourcemaps.md
@@ -53,9 +53,5 @@ airbrake.addFilter(function(notice) {
 
 ## Sourcemaps and Node.js
 
-For server side sourcemaps, please use the following steps:
-1. Upload sourcemap to Airbrake using our [Private Sourcemaps
-   feature](/docs/features/private-sourcemaps/)
-2. Link the minified JS files to the corresponding sourcemap using the [custom
-   sourcemap URLs](/docs/features/public-sourcemaps/#custom-sourcemap-urls)
-   feature
+For server side sourcemaps, please check out our [Private Sourcemaps for server
+side apps](/docs/features/private-sourcemaps/#sourcemaps-and-nodejs) section.


### PR DESCRIPTION
Moves the "server side sourcemaps" section over to the Private Sourcemaps doc while keeping a section that links to it from the Public Sourcemaps doc. This is to make the section easier to find for users.

Custom sourcemap URLs section remains in the Public Sourcemaps doc since it's not a feature that's specific to Private Sourcemaps. Correct me if I'm wrong @vmihailenco. 

### Changes: private sourcemaps doc
<img width="725" alt="screen shot 2018-12-18 at 11 48 00 am" src="https://user-images.githubusercontent.com/2172513/50179255-664d6980-02bb-11e9-90a6-37dc614c158b.png">


### Changes: public sourcemaps doc
<img width="712" alt="screen shot 2018-12-18 at 11 48 18 am" src="https://user-images.githubusercontent.com/2172513/50179280-78c7a300-02bb-11e9-96b4-cf6073fb2415.png">
