### PR TITLE
Fix docs deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,15 @@ jobs:
       - run:
           name: Deploy docs to production or staging
           command: |
+            # We tell the s3_website gem to only download the .jar file, and
+            # then we manually invoke it. This was added as a workaround for
+            # error `Failed to parse ERB in staging/s3_website.yml`.
+            # There will probably be a different long-term fix when
+            # https://github.com/laurilehmijoki/s3_website/issues/323 is
+            # resolved.
+            bundle exec s3_website install
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              bundle exec s3_website push --site jekyll/_site/production
+              java -cp $(bundle show s3_website)/*.jar s3.website.Push --site jekyll/_site/production
             else
-              bundle exec s3_website push --config-dir staging --site jekyll/_site/staging
+              java -cp $(bundle show s3_website)/*.jar s3.website.Push --config-dir staging --site jekyll/_site/staging
             fi


### PR DESCRIPTION
This fixes issue with `s3_website` while pushing Jekyll site to
staging/production:
```
[fail] Could not load the site: Failed to parse ERB in staging/s3_website.yml:
(SyntaxError) /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_warn.rb:15: syntax error, unexpected tLABEL
module_function define_method(:warn) {|*messages, uplevel: nil|
```

Examples of failed builds:
- https://circleci.com/gh/airbrake/airbrake-docs/1076
- https://circleci.com/gh/airbrake/airbrake-docs/1070

The fix is to tell the `s3_website` gem to only download the `.jar` file,
then manually invoke it.

There is an opened related issue in https://github.com/laurilehmijoki/s3_website/issues/323.

I've verified this fix is working by submitting a test change in [`test-docs-update`](https://github.com/airbrake/airbrake-docs/commits/test-docs-update) branch. It's deployed properly to staging.