### PR TITLE
Update the gem upgrade doc

### DIFF
--- a/jekyll/_docs/ruby/upgrading-your-notifier.md
+++ b/jekyll/_docs/ruby/upgrading-your-notifier.md
@@ -4,35 +4,32 @@ title: Upgrading your notifier
 categories: [ruby]
 description: Upgrading your notifier
 ---
-### Step 1: Update your gems
+> **Note:** If you are upgrading from version `4.X.X` or older, please
+follow our [guide to upgrade from a deprecated version](/docs/ruby/upgrading-from-deprecated-versions/).
 
-Upgrade to the latest version of our gem by updating your Gemfile:
-
-_**Note:** our gem is
-updated frequently, you can always find the current version on
-[RubyGems](https://rubygems.org/gems/airbrake) or on [our
-GitHub](https://github.com/airbrake/airbrake/releases)._
+**Step 1:** To upgrade to the latest version of the
+[airbrake gem](https://github.com/airbrake/airbrake)
+just edit your `Gemfile`:
 
 ```rb
 gem 'airbrake', '~> 9.4'
 ```
 
-Then run the update command to update our main gem and the `airbrake-ruby` gem
-it uses:
+**Step: 2:** Run the update command to update the `airbrake` gem and `airbrake-ruby` gem
+it depends on:
 
 ```
 bundle update airbrake airbrake-ruby
 ```
 
-### Step 2: Update config
+That's it! Your upgrade is complete.
 
-To track Performance Monitoring data, enable
-[the `performance_stats` option](https://github.com/airbrake/airbrake-ruby#performance_stats)
-in your `config/initializers/airbrake.rb` file. Get more info about
-[Performance Monitoring](https://airbrake.io/product/performance).
-```rb
-Airbrake.configure do |c|
-  # Add the following line to your config:
-  c.performance_stats = true
-end
-```
+> **Note:** by default, current versions of our gem **monitor performance** along
+with errors. If you want to disable performance monitoring, set the
+[`performance_stats`
+option](https://github.com/airbrake/airbrake-ruby#performance_stats) to
+`false`.
+
+#### Problems upgrading?
+If you run into any issues upgrading, we are happy to help. Just let us
+know what happened at [support@airbrake.io](mailto:support@airbrake.io).


### PR DESCRIPTION
- Now that performance stats are enabled by default there is no need to
enable performance monitoring manually, instead I've added a note about
performance monitoring being on by default.
- Add some contact info if the user has trouble upgrading
- Add a note about our upgrade from deprecated versions guide
- Remove most current version note to keep the doc a little cleaner.

Before | After
---|---
![Screen Shot 2019-08-07 at 10 59 44 AM](https://user-images.githubusercontent.com/940237/62646167-8a20f680-b902-11e9-847a-9410b17643e4.png)|![Screen Shot 2019-08-07 at 11 22 35 AM](https://user-images.githubusercontent.com/940237/62647601-c30e9a80-b905-11e9-96e1-48a989a0eaae.png)

