### PR TITLE
FAQs: Fix the Performance Monitoring Pricing

### DIFF
--- a/jekyll/_docs/performance-monitoring/frequently-asked-questions.md
+++ b/jekyll/_docs/performance-monitoring/frequently-asked-questions.md
@@ -42,7 +42,7 @@ period.
 
 | Requests monitored | Price      |
 |--------------------|------------|
-| Up to 5 thousand   | Free       |
+| Up to 50 thousand  | Free       |
 | Up to 5 million    | $99        |
 | Up to 10 million   | $149       |
 | Up to 20 million   | $249       |


### PR DESCRIPTION
The Performance Monitoring free usage increased to 50K shortly after
launch.