### PR TITLE
Reorg/getting started

### DIFF
--- a/jekyll/_includes/sidebar.html
+++ b/jekyll/_includes/sidebar.html
@@ -1,38 +1,22 @@
 <nav class="sidebar">
   <div class="visible-xs">
-    Select a page:
+    Select a category
     <select id="mobile-nav" class="mobile-nav">
-      <option value="https://airbrake.io/docs/api/">API Reference</option>
+      <option value="{{ site.baseurl }}/">Docs Home</option>
       {% for category in site.data.categories %}
         {% assign category_url = category.index | prepend: '/' | append: '/' %}
         <option value="{{ site.baseurl }}/{{ category.index }}/"
           {% if page.url == category_url %}selected{% endif %}>
           {{ category.name }}
         </option>
-        {% for doc in site.docs %}
-          {% if (doc.categories contains category.slug) and (doc.slug != category.index) %}
-            {% if doc.short-title %}
-              {% assign title = doc.short-title %}
-            {% else %}
-              {% assign title = doc.title %}
-            {% endif %}
-            {% if doc.children %}
-              {% capture title %}{{ title }} ({{ doc.children | size }}){% endcapture %}
-            {% endif %}
-            <option value="{{ site.baseurl }}{{ doc.url }}"
-              {% if page.url == doc.url %}selected{% endif %}>
-              &nbsp;&nbsp;{{ title }}
-            </option>
-          {% endif %}
-        {% endfor %}
       {% endfor %}
+      <option value="https://airbrake.io/docs/api/">API Reference</option>
     </select>
   </div>
 
   <ul class="list-unstyled hidden-xs">
     <li>
-      <a href="https://airbrake.io/docs/api/" class="sidebar-link sidebar-link--title"
-         target="_blank">API Reference</a>
+      <a href="{{ site.baseurl }}/" class="sidebar-link sidebar-link--title">Docs Home</a>
     </li>
     {% capture sidebar %}
     {% for category in site.data.categories %}
@@ -41,28 +25,6 @@
       <a class="sidebar-link sidebar-link--title{% if page.url == category_url %} sidebar-link--active{% endif %}" href="{{ site.baseurl }}/{{ category.index }}/">
         {{ category.name }}
       </a>
-      <ul class="list-unstyled sidebar-sublist">
-        {% for doc in site.docs %}
-        {% if (doc.categories contains category.slug) and (doc.slug != category.index) %}
-        {% if doc.short-title %}
-        {% assign title = doc.short-title %}
-        {% else %}
-        {% assign title = doc.title %}
-        {% endif %}
-
-        {% if doc.children %}
-        {% capture title %}{{ title }} ({{ doc.children | size }}){% endcapture %}
-        {% endif %}
-
-        <li>
-          <a class="sidebar-link{% if page.url == doc.url %} sidebar-link--active{% endif %}"
-            href="{{ site.baseurl }}{{ doc.url }}">
-            {{ title }}
-          </a>
-        </li>
-        {% endif %}
-        {% endfor %}
-      </ul>
     </li>
     {% endfor %}
     {% endcapture %}
@@ -70,6 +32,10 @@
     <li>
       <a href="/docs/airbrake-logo-guidelines/" class="sidebar-link sidebar-link--title"
          target="_blank">Airbrake logo guidelines</a>
+    </li>
+    <li>
+      <a href="https://airbrake.io/docs/api/" class="sidebar-link sidebar-link--title"
+         target="_blank">API Reference</a>
     </li>
     <li>
       <a href="/docs/legacy-xml-api/" class="sidebar-link sidebar-link--title"

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -17,7 +17,7 @@
             <ul id="search-results" class="list-unstyled dropdown-menu"></ul>
           </form>
           <article>
-            <h1>{{ page.title }}</h1>
+            {% if page.title %}<h1>{{ page.title}}</h1>{% endif %}
             {{ content }}
             {% if page.collection == "docs" and page.layout == "classic-docs" %}
               {% include doc-footer.html %}

--- a/jekyll/_sass/base/_base.scss
+++ b/jekyll/_sass/base/_base.scss
@@ -25,6 +25,7 @@ a:hover {
 }
 
 .ab-sm-row-flex {
+  min-height: 75vh;
   @media (min-width: $screen-sm-min) {
     display: flex;
   }

--- a/jekyll/_sass/base/_content.scss
+++ b/jekyll/_sass/base/_content.scss
@@ -1,5 +1,6 @@
 .content-wrap {
   background: $ab-white;
+  min-height: 75vh;
 
   @media (min-width: $screen-sm-min) {
     box-shadow: inset 1px 0px 0px $ab-grey-800;
@@ -7,7 +8,7 @@
 }
 
 .content {
-  max-width: 850px;
+  max-width: 1300px;
   padding: $padding-sidebar-content;
   color: $ab-grey-300;
   font-size: $fontXDefault;
@@ -16,12 +17,8 @@
     padding: 2em;
   }
 
-  #site-search {
-    margin-bottom: 2em;
-  }
-
   h1, h2, h3, h4, h5, h6 {
-    margin-top: 1.5em;
+    margin-top: 1em;
     margin-bottom: 1em;
   }
 

--- a/jekyll/_sass/base/_content.scss
+++ b/jekyll/_sass/base/_content.scss
@@ -8,7 +8,7 @@
 }
 
 .content {
-  max-width: 1300px;
+  max-width: 100vw;
   padding: $padding-sidebar-content;
   color: $ab-grey-300;
   font-size: $fontXDefault;
@@ -50,3 +50,26 @@
     }
   }
 }
+
+.category-flex-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  margin-left: -15px;
+  margin-right: -15px;
+}
+
+.category-flex-row div {
+  @media (max-width: 1300px) {
+    flex-basis: 100%;
+  }
+  flex-basis: 49%;
+  margin-top: 1.5em;
+  padding-left: 1em;
+  padding-right: 1em;
+
+  border: 1px solid $ab-grey-900;
+  border-radius: 5px;
+}
+

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -2,30 +2,52 @@
 layout: classic-docs
 ---
 
-<div class="alert alert-info">
-  If you are looking for the full Airbrake API reference, please visit our <strong>
-  <a target="_blank" href="{{ site.url }}/docs/api/">API Docs</a></strong>.
+<div class="container-fluid">
+  <div class="category-flex-row">
+    <div>
+      <h2><a href="{{ site.baseurl }}/installing-airbrake/">Getting Started</a></h2>
+      <p>Learn how to install Airbrake in your application in minutes. If you are
+      writing code, we've got an error notifier for your favorite programming
+      languages and frameworks.</p>
+    </div>
+    <div>
+      <h2><a href="{{ site.baseurl}}/performance-monitoring/">Performance Monitoring</a></h2>
+      <p>Our Performance Monitoring was designed with developers in mind, it's
+      easy to install and let's you see a broad performance overview, measure
+      user satisfaction, identify routes with poor performance and dive deep
+      into why.
+      </p>
+    </div>
+    <div>
+      <h2><a href="{{ site.baseurl }}/integrations/">Integrations</a></h2>
+      <p>Add Airbrake into your existing workflow. Post errors to slack, create
+      github issues from errors, create trello cards and more!</p>
+    </div>
+    <div>
+      <h2><a href="{{ site.baseurl }}/features/">Airbrake Features</a></h2>
+      <p>Learn the ins and outs of Airbrakes most powerful features and how to
+      make them work for you.</p>
+    </div>
+    <div>
+      <h2><a href="{{ site.baseurl }}/airbrake-faq/">Airbrake FAQs</a></h2>
+      <p>Dig deeper and find answers to the most common questsions, and
+        a collection of tricks and troubleshooting tips.
+      </p>
+    </div>
+    <div>
+      <h2><a href="{{ site.baseurl }}/airbrake-faq/security/">Security</a></h2>
+      <p>Information on Airbrake's security and additional guides on how to keep
+      your data secure while using Airbrbake.</p>
+    </div>
+    <div>
+      <h2><a href="{{ site.baseurl }}/billing/">Billing</a></h2>
+      <p>Find all your answers about our billing policies here. Get an in depth
+      look into monthly quota pricing for Error Monitoring and information on
+      our tiered pricing for Perfomance Monitoring.</p>
+    </div>
+    <div>
+      <h2><a href="https://airbrake.io/docs/api/" target="_blank">API Reference</a></h2>
+      <p>Get full access to your error data and more through our REST API</p>
+    </div>
+  </div>
 </div>
-
-{% for category in site.data.categories %}
-  <h2>{{ category.name }}</h2>
-  <ul class="list-unstyled">
-    {% assign docs_found = 0 %}
-    {% for doc in site.docs %}
-      {% if doc.categories contains category.slug and doc.slug != category.index %}
-        {% assign docs_found = docs_found | plus: 1 %}
-        {% if docs_found < 4 %}
-          {% if doc.short-title %}
-            <li class="{% if page.path contains doc.url %}active{% endif %}"><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.short-title }}</a></li>
-          {% else %}
-            <li><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></li>
-          {% endif %}
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-    {% if docs_found > 3 %}
-      {% assign more = docs_found | minus: 3 %}
-        <li><em><a href="{{ site.baseurl }}/{{ category.index }}/">{{ more }} more</a></em></li>
-      {% endif %}
-  </ul>
-{% endfor %}


### PR DESCRIPTION
This update provides a landing page refresh reorganizing the categories and providing short descriptions for each. The new categories feel more distinct and descriptive. The sidebar has also been tidied up, it no longer shows every single doc in the category.

### Before
<img width="1903" alt="Screen Shot 2019-08-23 at 5 58 06 PM" src="https://user-images.githubusercontent.com/940237/63630461-cecdb280-c5cf-11e9-93ed-e828a01b70d9.png">

### After
<img width="1904" alt="Screen Shot 2019-08-23 at 5 57 25 PM" src="https://user-images.githubusercontent.com/940237/63630463-d4c39380-c5cf-11e9-88d8-ad1318e5ec9b.png">
