### PR TITLE
Fix button height when viewport height is small

### DIFF
--- a/jekyll/_sass/base/_content.scss
+++ b/jekyll/_sass/base/_content.scss
@@ -81,7 +81,6 @@
 }
 
 #install-guides {
-  a { height: 11vh; }
-  img { height: 6vh; }
+  img { height: 6em; }
   .doc-title { padding-top: 1em; }
 }


### PR DESCRIPTION
On smaller viewport heights the text was floating out of the button
area.