### PR TITLE
Add a Perfomance Monitoring doc for Go

### DIFF
--- a/jekyll/_docs/performance-monitoring/frequently-asked-questions.md
+++ b/jekyll/_docs/performance-monitoring/frequently-asked-questions.md
@@ -24,7 +24,7 @@ get you the rest of the way.
 We currently support Performance Monitoring tracking for our
 [Rails](/docs/performance-monitoring/getting-started/) and have beta
 Performance Monitoring support for
-[Go](https://github.com/airbrake/gobrake#sending-routes-stats),
+[Go](/docs/performance-monitoring/go/),
 [Django](https://github.com/airbrake/pybrake#django-integration), and
 [Flask](https://github.com/airbrake/pybrake#flask-integration) projects.
 

--- a/jekyll/_docs/performance-monitoring/getting-started.md
+++ b/jekyll/_docs/performance-monitoring/getting-started.md
@@ -1,9 +1,9 @@
 ---
 layout: classic-docs
-title: Getting started with Performance Monitoring
-short-title: Getting started
+title: Performance Monitoring for Rails apps
+short-title: Performance Monitoring for Rails
 categories: [performance-monitoring]
-description: Getting started with Performance Monitoring
+description: Performance Monitoring for Rails apps
 ---
 
 Application Performance Monitoring with Airbrake makes it easy to:
@@ -12,16 +12,6 @@ Application Performance Monitoring with Airbrake makes it easy to:
 - Identify routes with problematic performance
 - Zoom into specific endpoints to see time spent in the DB, view, cache,
   external requests, and more
-
-## Supported languages
-
-Performance Monitoring is available for
-[Rails projects](#rails-installation),
-and is in beta for
-[Go](#golang-support),
-[Django](#django-and-flask-support), and
-[Flask apps](#django-and-flask-support). Is there a language you'd like us to support? Let us
-know at [support@airbrake.io](mailto:support@airbrake.io).
 
 ## Rails installation
 
@@ -55,28 +45,22 @@ If you are upgrading from a previous version of our gem, please follow [our
 upgrade guide](/docs/ruby/upgrading-your-notifier/) to get started with
 Performance Monitoring.
 
-## Golang support
+## Performance Monitoring for other languages
 
-Go support for Performance Monitoring is currently in beta and currently
-features:
-- Sending route stats
-- HTTP middlewares for Gin and Beego users
-- Wrapping important code blocks for detailed timing
-- Collecting stats about individual SQL queries
+Performance Monitoring is in an early access stage for [Go](/docs/performance-monitoring/go/),
+[Django](#django-and-flask-support), and [Flask apps](#django-and-flask-support). Is there a language you'd like us to support? Let us
+know at [support@airbrake.io](mailto:support@airbrake.io).
 
-Check out [our official GitHub
-repo](https://github.com/airbrake/gobrake#sending-routes-stats) to get started.
+### Django and Flask support
 
-## Django and Flask support
-
-Performance Monitoring for Django and Flask apps is currently in beta and is
+Performance Monitoring for Django and Flask apps is currently in early access and is
 supported out of the box - no extra setup required. All you have to do is
 install the latest version of the library. Check out our official GitHub repo
 for more info:
 - [View Django setup guide](https://github.com/airbrake/pybrake#django-integration)
 - [View Flask documentation](https://github.com/airbrake/pybrake#flask-integration)
 
-## Performance Dashboard
+## Performance Dashboard Features
 
 View all of your app’s performance stats at a glance. Trend cards highlight key
 performance metrics across your whole app. The charts show requests, response

--- a/jekyll/_docs/performance-monitoring/go.md
+++ b/jekyll/_docs/performance-monitoring/go.md
@@ -1,0 +1,146 @@
+---
+layout: classic-docs
+title: Performance Monitoring for Go applications
+short-title: Performance Monitoring for Go
+categories: [performance-monitoring]
+description: Performance Monitoring for Go applications
+---
+
+Application Performance Monitoring with Airbrake makes it easy to:
+- See a broad performance overview for your whole application
+- Measure user satisfaction with your app performance using Apdex
+- Identify routes with problematic performance
+- Zoom into specific endpoints to see time spent in the DB, view, cache,
+  external requests, and more
+
+## Go Support
+
+**Go support for Performance Monitoring is currently in early access** and
+features:
+- Sending route stats
+- HTTP middlewares for Gin and Beego users
+- Wrapping important code blocks for detailed timing
+- Collecting stats about individual SQL queries
+
+## Step 1: Install the latest version of gobrake
+
+{% highlight bash %}
+go get github.com/airbrake/gobrake
+{% endhighlight %}
+
+## Step 2: Configure gobrake and start sending route stats
+
+Before you can send performance stats replace the placeholder `ProjectId` and
+`ProjectKey` values from the example below with the real values from your
+project's setting page.
+
+Now that your gobrake notifier is configured let's collect some routes stats, we
+will use a simple net/http middleware in this example.
+
+> **Note**: If you use **Gin** or **Beego**, gobrake provides middleware out of
+the box and you may find our example apps more helpful:
+[Gin example](https://github.com/airbrake/gobrake/tree/master/examples/gin),
+[BeeGo example](https://github.com/airbrake/gobrake/tree/master/examples/beego).
+
+{% highlight go %}
+package main
+
+import (
+  "fmt"
+  "net/http"
+
+  "github.com/airbrake/gobrake"
+)
+
+// Airbrake is used to report errors and track performance
+var Airbrake = gobrake.NewNotifierWithOptions(&gobrake.NotifierOptions{
+  ProjectId: 123123,               // <-- Fill in this value
+  ProjectKey: "YourProjectAPIKey", // <-- Fill in this value
+  Environment: "Production",
+})
+
+func indexHandler(w http.ResponseWriter, req *http.Request) {
+  fmt.Fprintf(w, "Hello, There!")
+}
+
+func main() {
+  fmt.Println("Server listening at http://localhost:5555/")
+  // Wrap the indexHandler with Airbrake Performance Monitoring middleware:
+  http.HandleFunc(airbrakePerformance("/", indexHandler))
+  http.ListenAndServe(":5555", nil)
+}
+
+func airbrakePerformance(route string, h http.HandlerFunc) (string, http.HandlerFunc) {
+  handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+    ctx := req.Context()
+    ctx, routeMetric := gobrake.NewRouteMetric(ctx, req.Method, route) // Starts the timing
+    arw := newAirbrakeResponseWriter(w)
+
+    h.ServeHTTP(arw, req)
+
+    routeMetric.StatusCode = arw.statusCode
+    Airbrake.Routes.Notify(ctx, routeMetric) // Stops the timing and reports
+    fmt.Printf("code: %v, method: %v, route: %v\n", arw.statusCode, req.Method, route)
+  })
+
+  return route, handler
+}
+
+type airbrakeResponseWriter struct {
+  http.ResponseWriter
+  statusCode int
+}
+
+func newAirbrakeResponseWriter(w http.ResponseWriter) *airbrakeResponseWriter {
+  // Returns 200 OK if WriteHeader isn't called
+  return &airbrakeResponseWriter{w, http.StatusOK}
+}
+
+func (arw *airbrakeResponseWriter) WriteHeader(code int) {
+  arw.statusCode = code
+  arw.ResponseWriter.WriteHeader(code)
+}
+{% endhighlight %}
+
+Once you run this example and perform some `curl`s or visit
+[localhost:5555/](http://localhost:5555/) in your browser, you will see
+performance requests in your project's performance dashboard.
+
+## Congratulations!
+
+Great job! If you've used this example in your app, you can visit your
+Airbrake project's Performance Dashboard to see your performance data! Soon
+enough you'll have more insights into your application's performance. In the
+meantime why not check out the [Performance Dashboard
+features](/docs/performance-monitoring/performance-dashboard-features/).
+If you have questions about Performance Monitoring, visit the [Performance
+Monitoring FAQ](/docs/performance-monitoring/frequently-asked-questions/).
+
+### Measuring timing of specific operations
+
+Need more visibility into a slow route? To get more detailed timing, you
+can wrap important blocks of code into spans. For example, you can create 2
+spans `sql` and `http` to measure timing of specific operations:
+
+{% highlight go %}
+metric := &gobrake.RouteMetric{
+    Method: c.Request.Method,
+    Route: routeName,
+    StartTime: time.Now(),
+}
+
+metric.StartSpan("sql")
+users, err := fetchUser(ctx, userID)
+metric.EndSpan("sql")
+
+metric.StartSpan("http")
+resp, err := http.Get("http://example.com/")
+metric.EndSpan("http")
+
+metric.StatusCode = http.StatusOK
+notifier.Routes.Notify(ctx, metric)
+{% endhighlight %}
+
+### Want to learn more?
+
+Want to learn more about gobrake? Check out [our official GitHub repo](https://github.com/airbrake/gobrake).

--- a/jekyll/_docs/performance-monitoring/performance-dashboard-features.md
+++ b/jekyll/_docs/performance-monitoring/performance-dashboard-features.md
@@ -1,0 +1,29 @@
+---
+layout: classic-docs
+title: Performance Dashboard Features
+short-title: Performance Dashboard Features
+categories: [performance-monitoring]
+description: Performance Dashboard Features
+---
+
+View all of your app’s performance stats at a glance. Trend cards highlight key
+performance metrics across your whole app. The charts show requests, response
+times, errors, and user satisfaction ([Apdex](https://apdex.org/apdexfaq.html))
+over time. The routes list exposes performance stats per route, making it easy
+to pinpoint and resolve issues.
+
+![Performance Dashboard](/docs/assets/img/docs/performance_monitoring/performance-dashboard.png)
+
+### Detailed route performance
+
+Diving deeper into an individual route, you can see the proportion of time
+spent in the database, cache, views, or making external requests. There are
+similar trend cards and performance charts to quickly understand the route
+performance. You can also click through from a route to its linked Airbrake
+errors.
+
+![Route View](/docs/assets/img/docs/performance_monitoring/route-view.png)
+
+Have questions about Performance Monitoring? Check out our [Performance
+Monitoring FAQ](/docs/performance-monitoring/frequently-asked-questions/) for
+more information.


### PR DESCRIPTION
This doc provides information on performance monitoring and a `net/http` middleware example to get our gophers up and running with Airbrake Performance Monitoring. Other updates include:
- Performance pages to link to the go performance doc.
- Title changed for the Performance Monitoring for Rails doc
  - now that we have more than one language to get started with...
-  Extract the Performance Dashboard Features to it's own doc. 

<details>
<summary>screenshot preview of the new Go doc</summary>

![perfect-go-mon](https://user-images.githubusercontent.com/940237/64829795-9d1e8a80-d582-11e9-9fdc-4e3e8c04dfca.png)


</details>