### PR TITLE
Mention performance stats in digest doc

### DIFF
--- a/jekyll/_docs/features/digests.md
+++ b/jekyll/_docs/features/digests.md
@@ -6,8 +6,9 @@ description: A glimpse of what happened on your account over a period of time em
 ---
 
 Digest emails provide a summary of what happened on your account, including new
-errors, occurrences & deploys across all projects you are subscribed to. The
-summary contains trends to help you understand how your projects are performing.
+errors, occurrences, deploys, and performance stats across all projects you are
+subscribed to. The summary contains trends to help you understand how your
+projects are performing.
 
 For example, the following digest shows a 250% increase of errors during one day
 in 88 projects an account has (7 errors yesterday vs 2 errors 2 days ago):


### PR DESCRIPTION
Since we now send performance stats in digest emails, we should mention
that in the relevant doc.

<img width="667" alt="Digest emails - Airbrake 2019-12-09 10-32-01" src="https://user-images.githubusercontent.com/2136477/70424168-33255c80-1a6f-11ea-9802-3c53f2856d9b.png">
