### PR TITLE
Merge pull request #418 from airbrake/group-perf-docs

### DIFF
--- a/jekyll/_docs/performance-monitoring.md
+++ b/jekyll/_docs/performance-monitoring.md
@@ -1,6 +1,13 @@
 ---
-layout: classic-category
+layout: grouped-categories
 title: Performance Monitoring
 categories: [performance-monitoring]
+groups: [
+  'About Performance Monitoring',
+  'Rails Performance Monitoring',
+  'Python Performance Monitoring',
+  'Go Performance Monitoring',
+  'Node Performance Monitoring'
+]
 description: Performance Monitoring
 ---

--- a/jekyll/_docs/performance-monitoring/django.md
+++ b/jekyll/_docs/performance-monitoring/django.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Performance Monitoring for Django apps
 short-title: Performance Monitoring for Django
 categories: [performance-monitoring]
+group: Python Performance Monitoring
 description: Performance Monitoring for Django
 ---
 

--- a/jekyll/_docs/performance-monitoring/django.md
+++ b/jekyll/_docs/performance-monitoring/django.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Performance Monitoring for Django apps
-short-title: Performance Monitoring for Django
+short-title: Monitoring Django apps
 categories: [performance-monitoring]
 group: Python Performance Monitoring
 description: Performance Monitoring for Django

--- a/jekyll/_docs/performance-monitoring/flask.md
+++ b/jekyll/_docs/performance-monitoring/flask.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Performance Monitoring for Flask apps
-short-title: Performance Monitoring for Flask
+short-title: Monitoring Flask apps
 categories: [performance-monitoring]
 group: Python Performance Monitoring
 description: Performance Monitoring for Flask

--- a/jekyll/_docs/performance-monitoring/flask.md
+++ b/jekyll/_docs/performance-monitoring/flask.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Performance Monitoring for Flask apps
 short-title: Performance Monitoring for Flask
 categories: [performance-monitoring]
+group: Python Performance Monitoring
 description: Performance Monitoring for Flask
 ---
 

--- a/jekyll/_docs/performance-monitoring/frequently-asked-questions.md
+++ b/jekyll/_docs/performance-monitoring/frequently-asked-questions.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Performance Monitoring FAQ
-short-title: Performance Monitoring FAQ
+short-title: FAQ
 categories: [performance-monitoring]
 group: About Performance Monitoring
 group-position: 3

--- a/jekyll/_docs/performance-monitoring/frequently-asked-questions.md
+++ b/jekyll/_docs/performance-monitoring/frequently-asked-questions.md
@@ -1,8 +1,10 @@
 ---
 layout: classic-docs
 title: Performance Monitoring FAQ
-short-title: FAQ
+short-title: Performance Monitoring FAQ
 categories: [performance-monitoring]
+group: About Performance Monitoring
+group-position: 3
 description: Performance Monitoring FAQ
 ---
 

--- a/jekyll/_docs/performance-monitoring/getting-started.md
+++ b/jekyll/_docs/performance-monitoring/getting-started.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Performance Monitoring Getting Started
-short-title: Performance Monitoring Getting Started
+short-title: Getting Started
 categories: [performance-monitoring]
 group: About Performance Monitoring
 group-position: 1

--- a/jekyll/_docs/performance-monitoring/getting-started.md
+++ b/jekyll/_docs/performance-monitoring/getting-started.md
@@ -3,6 +3,8 @@ layout: classic-docs
 title: Performance Monitoring Getting Started
 short-title: Performance Monitoring Getting Started
 categories: [performance-monitoring]
+group: About Performance Monitoring
+group-position: 1
 description: Getting Started with Performance Monitoring
 ---
 

--- a/jekyll/_docs/performance-monitoring/go.md
+++ b/jekyll/_docs/performance-monitoring/go.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Performance Monitoring for Go applications
-short-title: Performance Monitoring for Go
+short-title: Monitoring Go apps
 categories: [performance-monitoring]
 group: Go Performance Monitoring
 description: Performance Monitoring for Go applications

--- a/jekyll/_docs/performance-monitoring/go.md
+++ b/jekyll/_docs/performance-monitoring/go.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Performance Monitoring for Go applications
 short-title: Performance Monitoring for Go
 categories: [performance-monitoring]
+group: Go Performance Monitoring
 description: Performance Monitoring for Go applications
 ---
 

--- a/jekyll/_docs/performance-monitoring/performance-dashboard-features.md
+++ b/jekyll/_docs/performance-monitoring/performance-dashboard-features.md
@@ -3,6 +3,8 @@ layout: classic-docs
 title: Performance Dashboard Features
 short-title: Performance Dashboard Features
 categories: [performance-monitoring]
+group: About Performance Monitoring
+group-position: 2
 description: Performance Dashboard Features
 ---
 

--- a/jekyll/_docs/performance-monitoring/performance-dashboard-features.md
+++ b/jekyll/_docs/performance-monitoring/performance-dashboard-features.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Performance Dashboard Features
-short-title: Performance Dashboard Features
+short-title: Dashboard Features
 categories: [performance-monitoring]
 group: About Performance Monitoring
 group-position: 2

--- a/jekyll/_docs/performance-monitoring/updating-from-airbrake-js-for-node.md
+++ b/jekyll/_docs/performance-monitoring/updating-from-airbrake-js-for-node.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Updating from airbrake-js for Node.js projects
 short-title: Updating from airbrake-js for Node.js projects
 categories: [performance-monitoring]
+group: Node Performance Monitoring
 description: How to update your Node.js project's notifier from airbrake-js
 ---
 

--- a/jekyll/_docs/performance-monitoring/updating-from-airbrake-js-for-node.md
+++ b/jekyll/_docs/performance-monitoring/updating-from-airbrake-js-for-node.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Updating from airbrake-js for Node.js projects
-short-title: Updating from airbrake-js for Node.js projects
+short-title: Updating from <code>airbrake-js</code> to <code>@airbrake/node</code>
 categories: [performance-monitoring]
 group: Node Performance Monitoring
 description: How to update your Node.js project's notifier from airbrake-js

--- a/jekyll/_docs/performance-monitoring/updating-from-deprecated-libraries-for-node.md
+++ b/jekyll/_docs/performance-monitoring/updating-from-deprecated-libraries-for-node.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Updating from node-airbrake for Node.js projects
-short-title: Updating from node-airbrake for Node.js projects
+short-title: Updating from <code>node-airbrake</code> to <code>@airbrake/node</code>
 categories: [performance-monitoring]
 group: Node Performance Monitoring
 description: How to update your Node.js project's notifier from node-airbrake

--- a/jekyll/_docs/performance-monitoring/updating-from-deprecated-libraries-for-node.md
+++ b/jekyll/_docs/performance-monitoring/updating-from-deprecated-libraries-for-node.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Updating from node-airbrake for Node.js projects
 short-title: Updating from node-airbrake for Node.js projects
 categories: [performance-monitoring]
+group: Node Performance Monitoring
 description: How to update your Node.js project's notifier from node-airbrake
 ---
 

--- a/jekyll/_docs/performance-monitoring/updating-to-pybrake-from-deprecated-versions.md
+++ b/jekyll/_docs/performance-monitoring/updating-to-pybrake-from-deprecated-versions.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Updating from older Python notifiers
 short-title: Updating from older Python notifiers
 categories: [performance-monitoring]
+group: Python Performance Monitoring
 description: How to update your Python notifier to the recommended library
 ---
 

--- a/jekyll/_docs/performance-monitoring/updating-your-go-notifier.md
+++ b/jekyll/_docs/performance-monitoring/updating-your-go-notifier.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Updating your Go notifier
 short-title: Updating your Go notifier
 categories: [performance-monitoring]
+group: Go Performance Monitoring
 description: How to update your Go notifier for Performance Monitoring
 ---
 

--- a/jekyll/_docs/performance-monitoring/updating-your-node-notifier.md
+++ b/jekyll/_docs/performance-monitoring/updating-your-node-notifier.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Updating your Node.js notifier
 short-title: Updating your Node.js notifier
 categories: [performance-monitoring]
+group: Node Performance Monitoring
 description: How to update your Node.js notifier for Performance Monitoring
 ---
 

--- a/jekyll/_docs/performance-monitoring/updating-your-python-notifier.md
+++ b/jekyll/_docs/performance-monitoring/updating-your-python-notifier.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Updating your Python notifier
 short-title: Updating your Python notifier
 categories: [performance-monitoring]
+group: Python Performance Monitoring
 description: How to update your Python notifier for Performance Monitoring
 ---
 

--- a/jekyll/_layouts/grouped-categories.html
+++ b/jekyll/_layouts/grouped-categories.html
@@ -1,0 +1,26 @@
+---
+layout: classic-docs
+---
+
+{% assign category = page.categories[0] %}
+<ul class="list-unstyled">
+{% if category == "api-2" %}
+  <li><strong>
+    <a href="https://airbrake.io/docs/api/">Full API Reference</a>
+  </strong></li>
+{% endif %}
+
+{% assign docs = site.docs | where: "categories", category %}
+{% assign groups = page.groups %}
+
+{% for group in page.groups %}
+  {% assign group_docs = docs | where: "group", group | sort: "group-position" %}
+  {% if group_docs != empty %}
+    <h3>{{ group }}</h3>
+    {% for doc in group_docs %}
+      <div>
+        <a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.short-title }}</a>
+      </div>
+    {% endfor %}
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
This groups the related docs based on general knowledge or by a specific language.
I removed as many instances of the phrase 'Performance Monitoring' as much as I could.

If we add a new performance doc, it will need to have a group defined in it's [Front Matter](https://jekyllrb.com/docs/front-matter/) and that group must match an entry in the [`performance-monitoring.md`'s groups array](https://github.com/airbrake/airbrake-docs/compare/group-perf-docs?expand=1#diff-9a4cdae37ce05747174137a4101ee9f8R5-R11).

before|after
---|---
![Screen Shot 2020-01-29 at 4 55 10 PM](https://user-images.githubusercontent.com/940237/73412118-7ad0a380-42bc-11ea-9c82-4794f7a70473.png)|![Screen Shot 2020-01-29 at 4 54 55 PM](https://user-images.githubusercontent.com/940237/73412106-7310ff00-42bc-11ea-8eef-0eb0f7301ac2.png)
