### PR TITLE
Merge pull request #420 from airbrake/extract-rails-instructions

### DIFF
--- a/jekyll/_docs/performance-monitoring/getting-started.md
+++ b/jekyll/_docs/performance-monitoring/getting-started.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: Performance Monitoring Getting Started
+title: Getting started with Performance Monitoring
 short-title: Getting Started
 categories: [performance-monitoring]
 group: About Performance Monitoring
@@ -8,40 +8,16 @@ group-position: 1
 description: Getting Started with Performance Monitoring
 ---
 
+### Feature overview
+
 {% include_relative partials/features-list.md %}
 
-## Supported languages
-- Rails (instructions below)
+### Select your language
+
+To start monitoring performance for your app, select a guide:
+
+- [Rails setup guide](/docs/performance-monitoring/rails/)
 - [Node.js (Express.js) setup guide](/docs/performance-monitoring/updating-your-node-notifier/)
 - [Go setup guide](/docs/performance-monitoring/go/)
 - [Django setup guide](/docs/performance-monitoring/django/)
 - [Flask documentation](/docs/performance-monitoring/flask/)
-
-## Rails installation
-
-Performance Monitoring is built into the same notifier you use to report errors
-from your application. To start sending performance data for your app to
-Airbrake just install or upgrade the Airbrake gem to the latest version.
-
-### Step 1: Install the latest version of the Airbrake gem
-
-Add the Airbrake gem to your `Gemfile`:
-
-```ruby
-gem 'airbrake'
-```
-
-To integrate Airbrake with your Rails application, invoke the following command
-and replace `PROJECT_ID` and `PROJECT_KEY` with your project's values:
-
-```shell
-rails g airbrake PROJECT_ID PROJECT_KEY
-```
-
-{% include_relative partials/congratulations.md %}
-
-### Upgrading from a previous gem version?
-
-If you are upgrading from a previous version of our gem, please follow [our
-upgrade guide](/docs/ruby/upgrading-your-notifier/) to get started with
-Performance Monitoring.

--- a/jekyll/_docs/performance-monitoring/rails.md
+++ b/jekyll/_docs/performance-monitoring/rails.md
@@ -1,0 +1,36 @@
+---
+layout: classic-docs
+title: Performance Monitoring for Rails applications
+short-title: Monitoring Rails apps
+categories: [performance-monitoring]
+group: Rails Performance Monitoring
+group-position: 1
+description: Performance Monitoring for Rails apps
+---
+
+Performance Monitoring is built into the same notifier you use to report errors
+from your application. To start sending performance data for your app to
+Airbrake just install or upgrade the Airbrake gem to the latest version.
+
+### Step 1: Install the latest version of the Airbrake gem
+
+Add the Airbrake gem to your `Gemfile`:
+
+```ruby
+gem 'airbrake'
+```
+
+To integrate Airbrake with your Rails application, invoke the following command
+and replace `PROJECT_ID` and `PROJECT_KEY` with your project's values:
+
+```shell
+rails g airbrake PROJECT_ID PROJECT_KEY
+```
+
+{% include_relative partials/congratulations.md %}
+
+### Upgrading from a previous gem version?
+
+If you are upgrading from a previous version of our gem, please follow [our
+upgrade guide](/docs/ruby/upgrading-your-notifier/) to get started with
+Performance Monitoring.

--- a/jekyll/_docs/ruby/upgrading-your-notifier.md
+++ b/jekyll/_docs/ruby/upgrading-your-notifier.md
@@ -1,7 +1,10 @@
 ---
 layout: classic-docs
 title: Upgrading your notifier
-categories: [ruby]
+short-title: Updating your Rails notifier
+categories: [ruby, performance-monitoring]
+group: Rails Performance Monitoring
+group-position: 2
 description: Upgrading your notifier
 ---
 > **Note:** If you are upgrading from version `4.X.X` or older, please


### PR DESCRIPTION
Extract the Rails instructions and list in the performance group.
List the upgrade notifier doc in the Rails performance group as well since the other languages have them. Rework the getting-started page to give better direction.
