### PR TITLE
Simplify ruby upgrade docs

### DIFF
--- a/jekyll/_docs/ruby/upgrading-from-deprecated-versions.md
+++ b/jekyll/_docs/ruby/upgrading-from-deprecated-versions.md
@@ -45,9 +45,3 @@ Overwrite /Users/arthur/my-app/config/initializers/airbrake.rb? (enter "h" for h
 
 For a full migration guide, check out
 [our doc on GitHub](https://github.com/airbrake/airbrake/blob/master/docs/Migration_guide_from_v4_to_v5.md).
-
-_**Note:** by default, current versions of our gem monitor performance along
-with errors. If you want to disable performance monitoring, set [the
-`performance_stats`
-option](https://github.com/airbrake/airbrake-ruby#performance_stats) to
-`false`._

--- a/jekyll/_docs/ruby/upgrading-from-hoptoad.md
+++ b/jekyll/_docs/ruby/upgrading-from-hoptoad.md
@@ -61,9 +61,3 @@ Overwrite /Users/arthur/my-app/config/initializers/airbrake.rb? (enter "h" for h
 
 For a full migration guide, check out
 [our doc on GitHub](https://github.com/airbrake/airbrake/blob/master/docs/Migration_guide_from_v4_to_v5.md).
-
-_**Note:** by default, current versions of our gem monitor performance along
-with errors. If you want to disable performance monitoring, set [the
-`performance_stats`
-option](https://github.com/airbrake/airbrake-ruby#performance_stats) to
-`false`._

--- a/jekyll/_docs/ruby/upgrading-your-notifier.md
+++ b/jekyll/_docs/ruby/upgrading-your-notifier.md
@@ -27,12 +27,6 @@ bundle update airbrake airbrake-ruby
 
 That's it! Your upgrade is complete.
 
-> **Note:** by default, current versions of our gem **monitor performance** along
-with errors. If you want to disable performance monitoring, set the
-[`performance_stats`
-option](https://github.com/airbrake/airbrake-ruby#performance_stats) to
-`false`.
-
 #### Problems upgrading?
 If you run into any issues upgrading, we are happy to help. Just let us
 know what happened at [support@airbrake.io](mailto:support@airbrake.io).


### PR DESCRIPTION
This information is available in the notifier readme. In the interest of
the simplest instructions possible the performance data note has been
removed.