### PR TITLE
Add Bootstrap overrides

### DIFF
--- a/jekyll/_sass/abstracts/_variables.scss
+++ b/jekyll/_sass/abstracts/_variables.scss
@@ -21,6 +21,8 @@ $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, 
 $font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 $font-family-base:        $font-family-sans-serif;
 
+$font-weight-normal: 400;
+
 $line-height-base:        1.428571429; // 20/14
 
 $spacer: 20px;
@@ -53,3 +55,20 @@ $body-color: $ab-grey-400;
 $pagination-disabled-bg: $ab-grey-1000;
 
 $link-color: $ab-blue-400;
+
+$alert-border-radius: 0;
+
+$badge-font-weight: $font-weight-normal;
+$badge-border-radius: 0;
+$badge-padding-y: .4em;
+$badge-padding-x: .6em;
+
+$card-border-width: 0;
+$card-border-radius: 0;
+
+$modal-backdrop-bg: $ab-grey-900;
+$modal-backdrop-opacity: 1;
+
+$table-bg: $ab-white;
+$table-cell-padding: 8px;
+$table-cell-padding-sm: 8px;

--- a/jekyll/_sass/application.scss
+++ b/jekyll/_sass/application.scss
@@ -1,14 +1,14 @@
-// 1. Configuration and helpers
+// Configuration and helpers
 @import
   "abstracts/airbrake-colors",
   "abstracts/mixins",
   "abstracts/variables";
 
-// 2. Vendors
+// Vendors
 @import
   "vendor/bootstrap/stylesheets/bootstrap";
 
-// 3. Base
+// Base
 @import
   "base/base",
   "base/buttons",
@@ -17,7 +17,7 @@
   "base/header",
   "base/sidebar";
 
-// 4. Helpers
+// Helpers
 @import
   "helpers/ab-sm-row-flex",
   "helpers/category-flex-row",
@@ -25,7 +25,7 @@
   "helpers/content-wrap",
   "helpers/highlight";
 
-// 5. Modules
+// Modules
 @import
   "modules/content-separator",
   "modules/image-list",

--- a/jekyll/_sass/application.scss
+++ b/jekyll/_sass/application.scss
@@ -17,6 +17,15 @@
   "base/header",
   "base/sidebar";
 
+// Bootstrap overrides
+@import
+  "bootstrap-overrides/badge",
+  "bootstrap-overrides/btn-group",
+  "bootstrap-overrides/card-header",
+  "bootstrap-overrides/dropdown",
+  "bootstrap-overrides/pagination",
+  "bootstrap-overrides/tooltip";
+
 // Helpers
 @import
   "helpers/ab-sm-row-flex",

--- a/jekyll/_sass/bootstrap-overrides/_badge.scss
+++ b/jekyll/_sass/bootstrap-overrides/_badge.scss
@@ -1,0 +1,32 @@
+.badge {
+  display: inline;
+  line-height: 1.7; // for vertical centering on Android (Roboto font)
+  color: $ab-white;
+  cursor: default;
+}
+
+.badge--default {
+  background-color: $ab-grey-500;
+}
+
+.badge--small {
+  font-size: $ab-font-size-x-small;
+  vertical-align: middle;
+
+  .glyphicon {
+    vertical-align: baseline;
+  }
+}
+
+.badge--icon {
+  background-color: $ab-blue-600;
+  cursor: pointer;
+
+  .glyphicon {
+    display: inline;
+    position: relative;
+    top: 2px;
+    font-size: $ab-font-size-default;
+    line-height: $ab-font-size-small;
+  }
+}

--- a/jekyll/_sass/bootstrap-overrides/_btn-group.scss
+++ b/jekyll/_sass/bootstrap-overrides/_btn-group.scss
@@ -1,0 +1,5 @@
+.btn-group {
+  .btn + .btn {
+    margin-left: 0;
+  }
+}

--- a/jekyll/_sass/bootstrap-overrides/_card-header.scss
+++ b/jekyll/_sass/bootstrap-overrides/_card-header.scss
@@ -1,0 +1,28 @@
+.card-header {
+  padding: 0;
+  position: relative;
+  font-size: $ab-font-size-default;
+  color: $ab-blue-400;
+  background: transparent;
+  border-bottom: 1px solid $ab-grey-900;
+  transition: padding 0.1s linear;
+
+  &:hover,
+  &:focus {
+    background: $ab-grey-900;
+    padding-left: 5px;
+    color: $ab-blue-200;
+  }
+
+  .btn-link {
+    all: unset;
+    width: 100%;
+    padding: 10px 0;
+
+    &:disabled {
+      opacity: 0.4;
+      color: $ab-grey-500;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/jekyll/_sass/bootstrap-overrides/_dropdown.scss
+++ b/jekyll/_sass/bootstrap-overrides/_dropdown.scss
@@ -1,0 +1,12 @@
+.dropdown-item:not([href]) {
+  &.active,
+  &:active {
+    color: $ab-white;
+  }
+}
+
+.dropdown-menu--reduced-padding {
+  .dropdown-item {
+    padding: 3px 10px;
+  }
+}

--- a/jekyll/_sass/bootstrap-overrides/_pagination.scss
+++ b/jekyll/_sass/bootstrap-overrides/_pagination.scss
@@ -1,0 +1,6 @@
+.pagination > li > a {
+  @extend .btn;
+  border: none;
+  border-radius: 0;
+  margin-left: 0;
+}

--- a/jekyll/_sass/bootstrap-overrides/_tooltip.scss
+++ b/jekyll/_sass/bootstrap-overrides/_tooltip.scss
@@ -1,0 +1,7 @@
+.tooltip--nowrap {
+  white-space: nowrap;
+
+  .tooltip-inner {
+    max-width: 300px;
+  }
+}


### PR DESCRIPTION
I'm adding styles for unused elements, for example .card-header. These come from our other repositories.

Even if were are not using these classes in `airbrake-docs`, I believe it's good to have them here a) to have parity between the codebases and b) if someone ever uses any of these elements in `airbrake-docs` the overrides will already be there.
